### PR TITLE
Implement Scene Graphs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0.0)
+cmake_minimum_required(VERSION 3.20)
 project(XRe)
 
 # TODO: will need to make this work with ARM64 later.
@@ -6,6 +6,8 @@ set(TARGET_ARCHITECTURE x64)
 
 # TODO: remove and fix warnings
 add_compile_options(-Wno-ignored-attributes)
+
+set(CMAKE_CXX_STANDARD 20)
 
 # Enable Action bindings other than khr/simple_controller. Comment this out to only use
 # khr/simple_controller for the Mixed Reality-Portal debugging.

--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0.0)
+cmake_minimum_required(VERSION 3.20)
 
 project(apps)
 

--- a/apps/scene_app/CMakeLists.txt
+++ b/apps/scene_app/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0.0)
+cmake_minimum_required(VERSION 3.20)
 
 project(scene_app)
 

--- a/apps/scene_app/main.cpp
+++ b/apps/scene_app/main.cpp
@@ -13,11 +13,14 @@ public:
   void setup() override {
     root_node.addChildNode(cube_node);
     cube_node.addChildNode(moon_node);
+    moon_node.translate(2.0f, 1.0f, 0.0f);
+    moon_node.scale(0.1f, 0.1f, 0.1f);
     root_node.updateTransformation();
   };
 
   void updateSimulation(XrTime predicted_time) override {
-
+    cube_node.rotate(0.0f, 0.0f, 0.01f);
+    root_node.updateTransformation();
   };
 
   void draw() override {

--- a/apps/scene_app/main.cpp
+++ b/apps/scene_app/main.cpp
@@ -4,8 +4,16 @@ class SceneApp : public Application {
 public:
   SceneApp(const char *application_name) : Application(application_name) {};
 
-  void setup() override {
+  Model cube = ModelFactory::createCube({0.0f, 0.0f, 1.0f, 1.0f});
+  Model moon_cube = ModelFactory::createCube({0.0f, 1.0f, 0.0f, 1.0f});
+  SceneNode root_node = SceneNode();
+  SceneNode cube_node = SceneNode(&cube);
+  SceneNode moon_node = SceneNode(&moon_cube);
 
+  void setup() override {
+    root_node.addChildNode(cube_node);
+    cube_node.addChildNode(moon_node);
+    root_node.updateTransformation();
   };
 
   void updateSimulation(XrTime predicted_time) override {
@@ -13,7 +21,7 @@ public:
   };
 
   void draw() override {
-
+    root_node.render();
   };
 };
 

--- a/apps/scene_app/main.cpp
+++ b/apps/scene_app/main.cpp
@@ -29,6 +29,7 @@ public:
   };
 
   void draw() override {
+    // TODO: do not consider bounding boxes if model is not rendered for intersection!
     root_node.render();
   };
 };

--- a/apps/scene_app/main.cpp
+++ b/apps/scene_app/main.cpp
@@ -4,8 +4,8 @@ class SceneApp : public Application {
 public:
   SceneApp(const char *application_name) : Application(application_name) {};
 
-  Model cube = ModelFactory::createCube({1.0f, 1.0f, 1.0f, 1.0f});
-  Model moon_cube = ModelFactory::createCube({1.0f, 1.0f, 1.0f, 1.0f});
+  Model cube = ModelFactory::createCube({1.0f, 0.0f, 0.0f, 1.0f});
+  Model moon_cube = ModelFactory::createCube({0.0f, 1.0f, 0.0f, 1.0f});
   SceneNode root_node = SceneNode();
   SceneNode cube_node = SceneNode(&cube);
   SceneNode moon_node = SceneNode(&moon_cube);
@@ -16,7 +16,7 @@ public:
     moon_node.translate(2.0f, 1.0f, 0.0f);
     moon_node.scale(0.1f, 0.1f, 0.1f);
     root_node.updateTransformation();
-    root_node.setGrabbable(true);
+    cube_node.setGrabbable(true);
   };
 
   void updateSimulation(XrTime predicted_time) override {

--- a/apps/scene_app/main.cpp
+++ b/apps/scene_app/main.cpp
@@ -4,8 +4,8 @@ class SceneApp : public Application {
 public:
   SceneApp(const char *application_name) : Application(application_name) {};
 
-  Model cube = ModelFactory::createCube({1.0f, 0.0f, 0.0f, 1.0f});
-  Model moon_cube = ModelFactory::createCube({0.0f, 1.0f, 0.0f, 1.0f});
+  Model cube = ModelFactory::createCube({0.56f, 0.93f, 0.56f, 1.0f});
+  Model moon_cube = ModelFactory::createCube({1.0f, 1.0f, 0.0f, 1.0f});
   SceneNode root_node = SceneNode();
   SceneNode cube_node = SceneNode(&cube);
   SceneNode moon_node = SceneNode(&moon_cube);

--- a/apps/scene_app/main.cpp
+++ b/apps/scene_app/main.cpp
@@ -4,8 +4,8 @@ class SceneApp : public Application {
 public:
   SceneApp(const char *application_name) : Application(application_name) {};
 
-  Model cube = ModelFactory::createCube({0.0f, 0.0f, 1.0f, 1.0f});
-  Model moon_cube = ModelFactory::createCube({0.0f, 1.0f, 0.0f, 1.0f});
+  Model cube = ModelFactory::createCube({1.0f, 1.0f, 1.0f, 1.0f});
+  Model moon_cube = ModelFactory::createCube({1.0f, 1.0f, 1.0f, 1.0f});
   SceneNode root_node = SceneNode();
   SceneNode cube_node = SceneNode(&cube);
   SceneNode moon_node = SceneNode(&moon_cube);

--- a/apps/scene_app/main.cpp
+++ b/apps/scene_app/main.cpp
@@ -16,6 +16,7 @@ public:
     moon_node.translate(2.0f, 1.0f, 0.0f);
     moon_node.scale(0.1f, 0.1f, 0.1f);
     root_node.updateTransformation();
+    root_node.setGrabbable(true);
   };
 
   void updateSimulation(XrTime predicted_time) override {

--- a/apps/scene_app/main.cpp
+++ b/apps/scene_app/main.cpp
@@ -6,17 +6,21 @@ public:
 
   Model cube = ModelFactory::createCube({0.56f, 0.93f, 0.56f, 1.0f});
   Model moon_cube = ModelFactory::createCube({1.0f, 1.0f, 0.0f, 1.0f});
+  Model floor = ModelFactory::createGroundPlane(10, DATA_FOLDER "/textures/Tiles012_2K-JPG_Color.jpg");
   SceneNode root_node = SceneNode();
+  SceneNode floor_node = SceneNode(&floor);
   SceneNode cube_node = SceneNode(&cube);
   SceneNode moon_node = SceneNode(&moon_cube);
 
   void setup() override {
     root_node.addChildNode(cube_node);
     cube_node.addChildNode(moon_node);
+    root_node.addChildNode(floor_node);
     moon_node.translate(2.0f, 1.0f, 0.0f);
     moon_node.scale(0.1f, 0.1f, 0.1f);
     root_node.updateTransformation();
     cube_node.setGrabbable(true);
+    floor_node.setIsTerrain(true);
   };
 
   void updateSimulation(XrTime predicted_time) override {

--- a/apps/simple_app/CMakeLists.txt
+++ b/apps/simple_app/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0.0)
+cmake_minimum_required(VERSION 3.20)
 
 project(simple_app)
 

--- a/apps/simple_app/main.cpp
+++ b/apps/simple_app/main.cpp
@@ -29,6 +29,9 @@ public:
   SceneNode sphere_1_node = SceneNode(&sphere, root_node);
   SceneNode sphere_2_node = SceneNode(&sphere, root_node);
   SceneNode sphere_3_node = SceneNode(&sphere, root_node);
+  SceneNode text_node = SceneNode(&text, root_node);
+  SceneNode quad_node = SceneNode(&quad, root_node);
+  SceneNode line_node = SceneNode(&line, root_node);
 
   void setup() override {
     spinning_cube_node.scale(0.3f, 0.3f, 0.3f);
@@ -65,13 +68,6 @@ public:
 
   void draw() override {
     root_node.render();
-
-    // Render the line
-    line.render();
-
-    // Render the flat bitmaps
-    quad.render();
-    text.render();
   };
 };
 

--- a/apps/simple_app/main.cpp
+++ b/apps/simple_app/main.cpp
@@ -4,21 +4,12 @@ class TestApp : public Application {
 public:
   TestApp(const char *application_name) : Application(application_name) {};
 
-  // Create shaders
-  Shader ambient_shader = Shader::loadOrCreate(SHADERS_FOLDER "/ambient.hlsl");
-  Shader color_shader = Shader::loadOrCreate(SHADERS_FOLDER "/color.hlsl");
-  Shader texture_shader = Shader::loadOrCreate(SHADERS_FOLDER "/ambient_texture.hlsl");
-
-  // Create models with the ModelFactory
-  Model spinning_cube = ModelFactory::createCube({1.0f, 0.0f, 0.0f, 0.25f});
-  Model ground_cube = ModelFactory::createCube(DirectX::XMFLOAT4(0.0f, 1.0f, 0.0f, 1.0f));
-  Model ground = ModelFactory::createGroundPlane(10, DATA_FOLDER "/textures/Tiles012_2K-JPG_Color.jpg");
-  Model small_cube = ModelFactory::createCube(DirectX::XMFLOAT4(0.0f, 0.0f, 1.0f, 1.0f));
+  Model floor = ModelFactory::createGroundPlane(10, DATA_FOLDER "/textures/Tiles012_2K-JPG_Color.jpg");
+  Model cube = ModelFactory::createCube({0.0f, 1.0f, 0.0f, 1.0f});
+  Model transparent_cube = ModelFactory::createCube({1.0f, 0.0f, 0.0f, 0.25f});
 
   // Create custom models
   Model sphere = Model(DATA_FOLDER "/models/sphere.obj");
-  Model sphere2 = Model(DATA_FOLDER "/models/sphere.obj");
-  Model sphere3 = Model(DATA_FOLDER "/models/sphere.obj");
 
   // Create a line
   Line line = Line({0.0f, 0.0f, 0.0f}, {10.0f, 10.0f, 5.0f}, {1.0f, 0.0f, 0.0f, 1.0f});
@@ -29,72 +20,58 @@ public:
   // Create some text with some valid and some invalid characters
   Text text = Text("This is a sample text :) カタカナ");
 
+  // Build the scene nodes
+  SceneNode root_node = SceneNode();
+  SceneNode floor_node = SceneNode(&floor, root_node);
+  SceneNode spinning_cube_node = SceneNode(&cube, root_node);
+  SceneNode moon_cube_node = SceneNode(&cube, spinning_cube_node);
+  SceneNode transparent_cube_node = SceneNode(&transparent_cube, root_node);
+  SceneNode sphere_1_node = SceneNode(&sphere, root_node);
+  SceneNode sphere_2_node = SceneNode(&sphere, root_node);
+  SceneNode sphere_3_node = SceneNode(&sphere, root_node);
+
   void setup() override {
-    // Scale the cube down a bit
-    spinning_cube.scale(0.33f, 0.33f, 0.33f);
+    spinning_cube_node.scale(0.3f, 0.3f, 0.3f);
+    spinning_cube_node.translate(1.0f, 1.0f, 1.0f);
+    spinning_cube_node.setGrabbable(true);
 
-    // And translate the cube up a bit
-    spinning_cube.translate(0.0f, 4.0f, 0.0f);
-    spinning_cube.setGrabbable(true);
+    moon_cube_node.translate(2.0f, 1.0f, 0.0f);
+    moon_cube_node.scale(0.1f, 0.1f, 0.1f);
 
-    // Scale the small cube down and translate it a bit. Also, mark it as grabbable.
-    small_cube.scale(0.1f, 0.1f, 0.1f);
-    small_cube.translate(2.0f, 1.5f, 0.0f);
-    small_cube.setGrabbable(true);
+    transparent_cube.m_has_transparency = true;
+    transparent_cube_node.scale(0.1f, 0.1f, 0.1f);
+    transparent_cube_node.translate(2.0f, 1.5f, 0.0f);
+    transparent_cube_node.setGrabbable(true);
 
-    sphere.scale(0.1f, 0.1f, 0.1f);
-    sphere.setGrabbable(true);
+    sphere_1_node.scale(0.1f, 0.1f, 0.1f);
 
-    // Translate the ground cube up a bit and to the left
-    ground_cube.translate(-2.0f, 0.5f, 0.0f);
-    ground_cube.setGrabbable(true);
+    sphere_2_node.scale(0.1f, 0.1f, 0.1f);
+    sphere_2_node.translate(1.0f, 0.0f, 2.0f);
 
-    // Squish the ground cube
-    ground_cube.scale(1.0f, 0.3f, 1.0f);
-
-    sphere2.scale(0.1f, 0.1f, 0.1f);
-    sphere2.translate(1.0f, 0.0f, 2.0f);
-    sphere2.setColor({1.0f, 0.0f, 0.0f, 1.0f});
-
-    sphere3.scale(0.1f, 0.1f, 0.1f);
-    sphere3.translate(-2.0f, 0.0f, -2.5f);
-    sphere3.setColor({0.0f, 1.0f, 0.0f, 1.0f});
+    sphere_3_node.scale(0.1f, 0.1f, 0.1f);
+    sphere_3_node.translate(-2.0f, 0.0f, -2.5f);
 
     // Set the ground to be terrain
-    ground.setIsTerrain(true);
+    floor_node.setIsTerrain(true);
   };
 
   void updateSimulation(XrTime predicted_time) override {
     // Rotate the cube
     // TODO: we should interpolate the rotation value such that it's
     // not coupled to the framerate
-    spinning_cube.rotate(0.0f, 0.0f, 0.01f);
+    spinning_cube_node.rotate(0.0f, 0.0f, 0.01f);
+    root_node.updateTransformation();
   };
 
   void draw() override {
-    // Render the ground
-    ground.render(texture_shader);
-
-    // Render the sphere
-    sphere.render(color_shader);
-    sphere2.render(color_shader);
-    sphere3.render(color_shader);
-
-    // Render the cube at the ground
-    ground_cube.render(ambient_shader);
+    root_node.render();
 
     // Render the line
-    line.render(color_shader);
-
-    // Render the small cube
-    small_cube.render();
+    line.render();
 
     // Render the flat bitmaps
     quad.render();
     text.render();
-
-    // Render a transparent looking cube
-    spinning_cube.renderTransparent(ambient_shader);
   };
 };
 

--- a/include/xre/application.h
+++ b/include/xre/application.h
@@ -11,7 +11,7 @@
 #include <xre/openxr_handler.h>
 #include <xre/model_factory.h>
 #include <xre/text.h>
-#include <xre/scene.h>
+#include <xre/scene_node.h>
 
 // Other includes
 #include <iostream>

--- a/include/xre/bitmap.h
+++ b/include/xre/bitmap.h
@@ -17,7 +17,7 @@ public:
 
 private:
   // A bitmap does not have a bounding box
-  inline bool hasBoundingBox() { return false; }
+  inline bool hasBoundingBox() override { return false; };
 
   Shader m_shader;
   DirectX::XMFLOAT4 m_bitmap_color;

--- a/include/xre/bounding_box_mesh.h
+++ b/include/xre/bounding_box_mesh.h
@@ -8,4 +8,8 @@ public:
   BoundingBoxMesh(std::vector<vertex_t> vertices);
 
   void render() override;
+  void updateVerticesFromBoundingBox(DirectX::BoundingOrientedBox bounding_box);
+
+private:
+  inline bool usesStaticBuffers() { return false; };
 };

--- a/include/xre/controller.h
+++ b/include/xre/controller.h
@@ -74,9 +74,6 @@ private:
   // Model to visualize intersections of the aim line
   // and models marked as interactable
   Model m_aim_indicator_sphere;
-  Shader m_aim_indicator_shader;
-
-  bool m_render_intersection_sphere = false;
 
   float computeAimIndicatorSpherePosition(std::unordered_set<SceneNode *> models);
 };

--- a/include/xre/controller.h
+++ b/include/xre/controller.h
@@ -61,12 +61,8 @@ private:
   // Threshold for showing the line intersection point
   static constexpr float s_line_intersection_threshold = 6.0f;
 
-  // Model and shader for the controller
+  // Model for the controller
   Model m_model;
-  Shader m_controller_shader;
-  SceneNode m_root_node;
-  SceneNode m_model_node;
-  SceneNode m_intersection_sphere_node;
 
   // Line for visualizing the aim direction
   Line m_aim_line;
@@ -74,6 +70,12 @@ private:
   // Model to visualize intersections of the aim line
   // and models marked as interactable
   Model m_aim_indicator_sphere;
+
+  // Scene nodes
+  SceneNode m_root_node;
+  SceneNode m_model_node;
+  SceneNode m_intersection_sphere_node;
+  SceneNode m_aim_line_node;
 
   float computeAimIndicatorSpherePosition(std::unordered_set<SceneNode *> models);
 };

--- a/include/xre/controller.h
+++ b/include/xre/controller.h
@@ -76,5 +76,5 @@ private:
 
   bool m_render_intersection_sphere = false;
 
-  float computeAimIndicatorSpherePosition(std::unordered_set<Model *> models);
+  float computeAimIndicatorSpherePosition(std::unordered_set<SceneNode *> models);
 };

--- a/include/xre/controller.h
+++ b/include/xre/controller.h
@@ -1,5 +1,8 @@
 #pragma once
 
+// DirectX includes
+#include <DirectXMath/DirectXMath.h>
+
 // Other includes
 #include <optional>
 

--- a/include/xre/controller.h
+++ b/include/xre/controller.h
@@ -64,6 +64,7 @@ private:
   // Model and shader for the controller
   Model m_model;
   Shader m_controller_shader;
+  SceneNode m_scene_node;
 
   // Line for visualizing the aim direction
   Line m_aim_line;

--- a/include/xre/controller.h
+++ b/include/xre/controller.h
@@ -14,6 +14,7 @@
 #include <xre/shader.h>
 #include <xre/model_factory.h>
 #include <xre/line.h>
+#include <xre/scene_node.h>
 
 class Controller {
 public:

--- a/include/xre/controller.h
+++ b/include/xre/controller.h
@@ -64,7 +64,9 @@ private:
   // Model and shader for the controller
   Model m_model;
   Shader m_controller_shader;
-  SceneNode m_scene_node;
+  SceneNode m_root_node;
+  SceneNode m_model_node;
+  SceneNode m_intersection_sphere_node;
 
   // Line for visualizing the aim direction
   Line m_aim_line;

--- a/include/xre/dx11_handler.h
+++ b/include/xre/dx11_handler.h
@@ -2,6 +2,7 @@
 
 // DirectX includes
 #include <d3d11.h>
+#include <DirectXMath/DirectXMath.h>
 
 // XRe includes
 #include <xre/utils.h>

--- a/include/xre/hand.h
+++ b/include/xre/hand.h
@@ -1,5 +1,9 @@
 #pragma once
 
+// DirectX includes
+#include <d3d11.h>
+#include <DirectXMath/DirectXMath.h>
+
 // OpenXR includes
 #include <open_xr/openxr.h>
 

--- a/include/xre/hand.h
+++ b/include/xre/hand.h
@@ -38,7 +38,9 @@ public:
 
 private:
   Shader m_joint_shader;
-  std::vector<Model> m_joints;
+  Model m_joint_model;
+  SceneNode m_hand_root_node;
+  std::vector<SceneNode*> m_joint_nodes;
 
   bool m_pinching = false;
 

--- a/include/xre/hand.h
+++ b/include/xre/hand.h
@@ -11,6 +11,7 @@
 #include <xre/model.h>
 #include <xre/shader.h>
 #include <xre/model_factory.h>
+#include <xre/scene_node.h>
 
 class Hand {
 public:

--- a/include/xre/line.h
+++ b/include/xre/line.h
@@ -16,9 +16,9 @@ public:
 
 private:
   // A line does not have a bounding box
-  inline bool hasBoundingBox() { return false; }
+  inline bool hasBoundingBox() override { return false; };
 
-  inline bool usesStaticBuffers() { return false; };
+  inline bool usesStaticBuffers() override { return false; };
 
   std::vector<vertex_t> verticesFromPoints(DirectX::XMFLOAT3 start, DirectX::XMFLOAT3 end);
 

--- a/include/xre/line.h
+++ b/include/xre/line.h
@@ -9,7 +9,6 @@ public:
   Line(DirectX::XMFLOAT3 line_start, DirectX::XMFLOAT3 line_end, DirectX::XMFLOAT4 color = DirectX::XMFLOAT4(1.0f, 1.0f, 1.0f, 1.0f));
 
   void render() override;
-  void render(Shader &shader);
   void updateAimLineFromControllerPose(DirectX::XMVECTOR controller_position, DirectX::XMVECTOR controller_orientation, DirectX::XMVECTOR current_origin, float length);
 
   DirectX::XMVECTOR getLineStart();

--- a/include/xre/mesh.h
+++ b/include/xre/mesh.h
@@ -21,6 +21,4 @@ public:
   Mesh();
   Mesh(std::vector<vertex_t> vertices, std::vector<unsigned int> indices);
   Mesh(std::vector<vertex_t> vertices, std::vector<unsigned int> indices, const char *texture_path);
-
-  void render() override;
 };

--- a/include/xre/model.h
+++ b/include/xre/model.h
@@ -19,8 +19,15 @@
 class Model {
 public:
   Model();
-  Model(std::vector<Mesh> meshes, DirectX::XMFLOAT4 color = DirectX::XMFLOAT4(0.8f, 0.8f, 0.8f, 1.0f));
-  Model(const char *model_path, DirectX::XMFLOAT4 color = DirectX::XMFLOAT4(0.8f, 0.8f, 0.8f, 1.0f));
+  Model(std::vector<Mesh> meshes);
+  Model(std::vector<Mesh> meshes, DirectX::XMFLOAT4 color);
+  Model(std::vector<Mesh> meshes, const char* shader_path);
+  Model(std::vector<Mesh> meshes, DirectX::XMFLOAT4 color, const char* shader_path);
+
+  Model(const char *model_path);
+  Model(const char *model_path, DirectX::XMFLOAT4 color);
+  Model(const char *model_path, const char* shader_path);
+  Model(const char *model_path, DirectX::XMFLOAT4 color, const char* shader_path);
 
   // Two different rendering methods, one where the user can pass in
   // a shader to use for this model

--- a/include/xre/model.h
+++ b/include/xre/model.h
@@ -13,6 +13,7 @@
 #include <xre/structs.h>
 #include <xre/dx11_handler.h>
 #include <xre/mesh.h>
+#include <xre/shader.h>
 #include <xre/bounding_box_mesh.h>
 
 class Model {
@@ -35,6 +36,7 @@ public:
 
   std::vector<DirectX::XMFLOAT3> getMeshBoundingBoxCorners();
 
+  Shader m_shader;
 private:
   // Pointer to the Dx11 handler
   inline static Dx11Handler *s_dx11_handler = NULL;

--- a/include/xre/model.h
+++ b/include/xre/model.h
@@ -86,6 +86,8 @@ public:
   static std::unordered_set<Model*> getGrabbableInstances();
   static std::unordered_set<Model*> getTerrainInstances();
 
+  std::vector<DirectX::XMFLOAT3> getMeshBoundingBoxCorners();
+
 private:
   // Pointer to the Dx11 handler
   inline static Dx11Handler *s_dx11_handler = NULL;

--- a/include/xre/model.h
+++ b/include/xre/model.h
@@ -26,6 +26,7 @@ public:
   void render();
   void render(Shader &shader);
   void renderTransparent(Shader &shader);
+  void renderInSceneNode();
 
   DirectX::XMMATRIX getTransformationMatrix();
   DirectX::XMMATRIX getRotationMatrix();
@@ -57,6 +58,7 @@ public:
   // Set the color of the model
   void setColor(DirectX::XMFLOAT4 color);
   void resetColor();
+  DirectX::XMFLOAT4 getColor();
 
   // Check whether a model intersects with a bounding box
   bool intersects(DirectX::BoundingOrientedBox other);

--- a/include/xre/model.h
+++ b/include/xre/model.h
@@ -60,19 +60,6 @@ public:
   void resetColor();
   DirectX::XMFLOAT4 getColor();
 
-  // Check whether a model intersects with a bounding box
-  bool intersects(DirectX::BoundingOrientedBox other);
-
-  // Check whether a model intersects with a line (and optionally put the
-  // distance of the intersection point as an out parameter)
-  bool intersects(DirectX::XMVECTOR line_start, DirectX::XMVECTOR line_direction, float *out_distance);
-
-  // Check whether a model contains a point
-  bool contains(DirectX::XMVECTOR point);
-
-  // Get the bounding box with the transformation already applied
-  DirectX::BoundingOrientedBox getTransformedBoundingBox();
-
   static void registerDx11Handler(Dx11Handler *handler);
 
   std::vector<DirectX::XMFLOAT3> getMeshBoundingBoxCorners();
@@ -101,15 +88,5 @@ private:
   // Store the original color
   DirectX::XMFLOAT4 m_original_model_color;
 
-  // The bounding box of this model, used to quickly check
-  // whether we need to check intersection with the meshes
-  // (if the bounding box of the model does not intersect,
-  // the bounding boxes of the meshes definitely will not).
-  DirectX::BoundingOrientedBox m_bounding_box;
-
   void loadObj(const char *model_path);
-  void buildBoundingBox();
-
-  // Apply the transform of the model to another bounding box (e.g. the bounding box of a child mesh)
-  DirectX::BoundingOrientedBox applyTransformToBoundingBox(DirectX::BoundingOrientedBox input_bounding_box);
 };

--- a/include/xre/model.h
+++ b/include/xre/model.h
@@ -24,36 +24,7 @@ public:
   // Two different rendering methods, one where the user can pass in
   // a shader to use for this model
   void render();
-  void render(Shader &shader);
-  void renderTransparent(Shader &shader);
-  void renderInSceneNode();
-
-  DirectX::XMMATRIX getTransformationMatrix();
-  DirectX::XMMATRIX getRotationMatrix();
-
-  // These methods apply the rotation / translation / scaling
-  // to the values we already have, e.g. to simply double the
-  // scale you could pass in a value of 2 to the `scale` method
-  void rotate(float roll, float pitch, float yaw);
-  void rotate(DirectX::XMVECTOR rotation);
-  void translate(float x, float y, float z);
-  void translate(DirectX::XMVECTOR translation);
-  void scale(float x, float y, float z);
-  void scale(DirectX::XMVECTOR scaling);
-
-  // These methods set the rotation / translation / scaling to
-  // the values passed in, use this if you already calculated the
-  // new values to use beforehand.
-  void setRotation(DirectX::XMVECTOR rotation);
-  void setScale(float x, float y, float z);
-  void setScale(DirectX::XMVECTOR scaling);
-  void setPosition(float x, float y, float z);
-  void setPosition(DirectX::XMVECTOR position);
-
-  // Getters for position, scale and rotation
-  DirectX::XMVECTOR getRotation();
-  DirectX::XMVECTOR getScale();
-  DirectX::XMVECTOR getPosition();
+  void renderTransparent();
 
   // Set the color of the model
   void setColor(DirectX::XMFLOAT4 color);
@@ -68,19 +39,8 @@ private:
   // Pointer to the Dx11 handler
   inline static Dx11Handler *s_dx11_handler = NULL;
 
-  // Track whether a model is currently grabbed (e.g. to stop animations when object is grabbed)
-  bool m_grabbed = false;
-
   // Vector holding all the meshes of this model
   std::vector<Mesh> m_meshes;
-
-  // Position, scale and rotation of the model
-  // Scale factors, initialize to use the scale of 1 for X, Y and Z
-  DirectX::XMVECTOR m_scaling = DirectX::XMVECTORF32({1.0f, 1.0f, 1.0f});
-  // The position of the object in world coordinates
-  DirectX::XMVECTOR m_translation = DirectX::XMVECTORF32({0.0f, 0.0f, 0.0f});
-  // The rotation of the model
-  DirectX::XMVECTOR m_rotation = DirectX::XMQuaternionIdentity();
 
   // Color of the model, which will be applied to all meshes
   DirectX::XMFLOAT4 m_model_color;

--- a/include/xre/model.h
+++ b/include/xre/model.h
@@ -124,9 +124,6 @@ private:
   // the bounding boxes of the meshes definitely will not).
   DirectX::BoundingOrientedBox m_bounding_box;
 
-  // Bounding box "mesh"
-  BoundingBoxMesh m_bounding_box_mesh;
-
   void loadObj(const char *model_path);
   void buildBoundingBox();
 

--- a/include/xre/model.h
+++ b/include/xre/model.h
@@ -29,10 +29,7 @@ public:
   Model(const char *model_path, const char* shader_path);
   Model(const char *model_path, DirectX::XMFLOAT4 color, const char* shader_path);
 
-  // Two different rendering methods, one where the user can pass in
-  // a shader to use for this model
   void render();
-  void renderTransparent();
 
   // Set the color of the model
   void setColor(DirectX::XMFLOAT4 color);
@@ -44,6 +41,9 @@ public:
   std::vector<DirectX::XMFLOAT3> getMeshBoundingBoxCorners();
 
   Shader m_shader;
+
+  bool m_has_transparency = false;
+
 private:
   // Pointer to the Dx11 handler
   inline static Dx11Handler *s_dx11_handler = NULL;
@@ -58,4 +58,7 @@ private:
   DirectX::XMFLOAT4 m_original_model_color;
 
   void loadObj(const char *model_path);
+
+  void renderWithTransparency();
+  void renderMeshes();
 };

--- a/include/xre/model.h
+++ b/include/xre/model.h
@@ -73,30 +73,13 @@ public:
   // Get the bounding box with the transformation already applied
   DirectX::BoundingOrientedBox getTransformedBoundingBox();
 
-  // Update the grabbable state of a model
-  void setGrabbable(bool grabbable);
-
-  void setGrabbed(bool grabbed);
-  bool getGrabbed();
-
-  // Update the is_terrain state of a model
-  void setIsTerrain(bool is_terrain);
-
   static void registerDx11Handler(Dx11Handler *handler);
-  static std::unordered_set<Model*> getGrabbableInstances();
-  static std::unordered_set<Model*> getTerrainInstances();
 
   std::vector<DirectX::XMFLOAT3> getMeshBoundingBoxCorners();
 
 private:
   // Pointer to the Dx11 handler
   inline static Dx11Handler *s_dx11_handler = NULL;
-
-  // Set of all instances we marked as grabbable models
-  inline static std::unordered_set<Model*> s_grabbable_instances;
-
-  // Set of all instances we marked as being terrain models
-  inline static std::unordered_set<Model*> s_terrain_instances;
 
   // Track whether a model is currently grabbed (e.g. to stop animations when object is grabbed)
   bool m_grabbed = false;

--- a/include/xre/model.h
+++ b/include/xre/model.h
@@ -2,6 +2,7 @@
 
 // DirectX includes
 #include <d3d11.h>
+#include <DirectXMath/DirectXMath.h>
 
 // Include other headers
 #include <vector>

--- a/include/xre/model_factory.h
+++ b/include/xre/model_factory.h
@@ -87,10 +87,8 @@ namespace ModelFactory {
     return Model({ ground_mesh });
   }
 
-  inline Model createSphere(float radius) {
+  inline Model createSphere() {
     Model sphere = Model(DATA_FOLDER "/models/sphere.obj");
-
-    sphere.scale(radius, radius, radius);
 
     return sphere;
   }

--- a/include/xre/model_factory.h
+++ b/include/xre/model_factory.h
@@ -84,7 +84,7 @@ namespace ModelFactory {
     auto [vertices, indices] = getGroundVerticesAndIndices(extent);
 
     Mesh ground_mesh = Mesh(vertices, indices, texture_path);
-    return Model({ ground_mesh });
+    return Model({ ground_mesh }, SHADERS_FOLDER "/ambient_texture.hlsl");
   }
 
   inline Model createSphere() {

--- a/include/xre/renderable.h
+++ b/include/xre/renderable.h
@@ -2,6 +2,7 @@
 
 // DirectX includes
 #include <d3d11.h>
+#include <DirectXMath/DirectXMath.h>
 #include <DirectXTex/WICTextureLoader11.h>
 #include <DirectXMath/DirectXCollision.h>
 

--- a/include/xre/renderable.h
+++ b/include/xre/renderable.h
@@ -18,7 +18,7 @@
 // can be rendered to display some output in the program.
 class Renderable {
 public:
-  virtual void render() {};
+  virtual void render();
   DirectX::BoundingOrientedBox getBoundingBox();
 
   static void registerDx11DeviceAndDeviceContext(ID3D11Device *device, ID3D11DeviceContext *device_context);

--- a/include/xre/renderable.h
+++ b/include/xre/renderable.h
@@ -59,6 +59,8 @@ protected:
   // to be updateable or not).
   bool m_static_buffers = true;
 
+  Shader m_shader;
+
   void initialize(std::vector<vertex_t> vertices, std::vector<unsigned int> indices);
   void createVertexBuffer(std::vector<vertex_t> data, ID3D11Buffer **target_buffer);
   void createIndexBuffer(std::vector<unsigned int> data, ID3D11Buffer **target_buffer);

--- a/include/xre/scene.h
+++ b/include/xre/scene.h
@@ -1,8 +1,0 @@
-
-
-class Scene {
-public:
-  void render();
-
-private:
-};

--- a/include/xre/scene_node.h
+++ b/include/xre/scene_node.h
@@ -45,6 +45,8 @@ public:
   static std::unordered_set<SceneNode*> getGrabbableInstances();
   void setGrabbable(bool grabbable);
 
+  bool intersects(DirectX::BoundingOrientedBox other);
+
 private:
   // Parent node (which might be null for the root node)
   SceneNode* m_parent;

--- a/include/xre/scene_node.h
+++ b/include/xre/scene_node.h
@@ -21,6 +21,25 @@ public:
   void render();
   void updateTransformation();
 
+  // These methods apply the rotation / translation / scaling
+  // to the values we already have, e.g. to simply double the
+  // scale you could pass in a value of 2 to the `scale` method
+  void rotate(float roll, float pitch, float yaw);
+  void rotate(DirectX::XMVECTOR rotation);
+  void translate(float x, float y, float z);
+  void translate(DirectX::XMVECTOR translation);
+  void scale(float x, float y, float z);
+  void scale(DirectX::XMVECTOR scaling);
+
+  // These methods set the rotation / translation / scaling to
+  // the values passed in, use this if you already calculated the
+  // new values to use beforehand.
+  void setRotation(DirectX::XMVECTOR rotation);
+  void setScale(float x, float y, float z);
+  void setScale(DirectX::XMVECTOR scaling);
+  void setPosition(float x, float y, float z);
+  void setPosition(DirectX::XMVECTOR position);
+
 private:
   // Parent node (which might be null for the root node)
   SceneNode* m_parent;

--- a/include/xre/scene_node.h
+++ b/include/xre/scene_node.h
@@ -18,6 +18,7 @@ public:
   ~SceneNode();
 
   void addChildNode(SceneNode &child);
+  void addChildNode(SceneNode *child);
   void render();
   void updateTransformation();
   void buildBoundingBox();

--- a/include/xre/scene_node.h
+++ b/include/xre/scene_node.h
@@ -78,9 +78,6 @@ private:
   // transformation)
   Model* m_model;
 
-  // TODO: remove when models have a default shader
-  Shader m_shader;
-
   // Position, scale and rotation of the SceneNode. These are all LOCAL,
   // i.e. in relation to the transform of the parent node!
   // Scale factors, initialize to use the scale of 1 for X, Y and Z

--- a/include/xre/scene_node.h
+++ b/include/xre/scene_node.h
@@ -15,6 +15,7 @@ class SceneNode {
 public:
   SceneNode();
   SceneNode(Model* model);
+  SceneNode(Model* model, SceneNode &parent);
   ~SceneNode();
 
   void addChildNode(SceneNode &child);

--- a/include/xre/scene_node.h
+++ b/include/xre/scene_node.h
@@ -49,13 +49,20 @@ public:
 
   static std::unordered_set<SceneNode*> getGrabbableInstances();
   void setGrabbable(bool grabbable);
+  static std::unordered_set<SceneNode*> getTerrainInstances();
+  void setIsTerrain(bool is_terrain);
 
+  // Check whether a node intersects with a bounding box
   bool intersects(DirectX::BoundingOrientedBox other);
+
+  // Check whether a node intersects with a line (and optionally put the
+  // distance of the intersection point as an out parameter)
+  bool intersects(DirectX::XMVECTOR line_start, DirectX::XMVECTOR line_direction, float *out_distance);
 
   bool m_grabbed = false;
   bool m_intersected_in_current_frame = false;
 
-  static void resetIntersectedStates();
+  static void resetInteractionStates();
 
 private:
   // Parent node (which might be null for the root node)
@@ -94,4 +101,6 @@ private:
 
   // Set of all instances we marked as grabbable
   inline static std::unordered_set<SceneNode*> s_grabbable_instances;
+
+  inline static std::unordered_set<SceneNode*> s_terrain_instances;
 };

--- a/include/xre/scene_node.h
+++ b/include/xre/scene_node.h
@@ -20,6 +20,7 @@ public:
   void addChildNode(SceneNode &child);
   void render();
   void updateTransformation();
+  void buildBoundingBox();
 
   // These methods apply the rotation / translation / scaling
   // to the values we already have, e.g. to simply double the
@@ -71,4 +72,7 @@ private:
 
   // Rotation relative to world
   DirectX::XMMATRIX m_world_rotation_matrix;
+
+  DirectX::BoundingOrientedBox m_model_bounding_box;
+  BoundingBoxMesh m_model_bounding_box_mesh;
 };

--- a/include/xre/scene_node.h
+++ b/include/xre/scene_node.h
@@ -42,6 +42,9 @@ public:
   void setPosition(float x, float y, float z);
   void setPosition(DirectX::XMVECTOR position);
 
+  static std::unordered_set<SceneNode*> getGrabbableInstances();
+  void setGrabbable(bool grabbable);
+
 private:
   // Parent node (which might be null for the root node)
   SceneNode* m_parent;
@@ -76,4 +79,7 @@ private:
 
   DirectX::BoundingOrientedBox m_model_bounding_box;
   BoundingBoxMesh m_model_bounding_box_mesh;
+
+  // Set of all instances we marked as grabbable
+  inline static std::unordered_set<SceneNode*> s_grabbable_instances;
 };

--- a/include/xre/scene_node.h
+++ b/include/xre/scene_node.h
@@ -21,6 +21,7 @@ public:
   void render();
   void updateTransformation();
   void buildBoundingBox();
+  DirectX::BoundingOrientedBox getTransformedBoundingBox();
 
   // These methods apply the rotation / translation / scaling
   // to the values we already have, e.g. to simply double the

--- a/include/xre/scene_node.h
+++ b/include/xre/scene_node.h
@@ -53,6 +53,9 @@ public:
   static std::unordered_set<SceneNode*> getTerrainInstances();
   void setIsTerrain(bool is_terrain);
 
+  void setActive(bool is_active);
+  bool isActive();
+
   // Check whether a node intersects with a bounding box
   bool intersects(DirectX::BoundingOrientedBox other);
 
@@ -64,9 +67,6 @@ public:
   bool m_intersected_in_current_frame = false;
 
   static void resetInteractionStates();
-
-  bool m_render = true;
-
 private:
   // Parent node (which might be null for the root node)
   SceneNode* m_parent;
@@ -105,4 +105,6 @@ private:
   inline static std::unordered_set<SceneNode*> s_terrain_instances;
 
   bool m_transform_needs_update = true;
+
+  bool m_is_active = true;
 };

--- a/include/xre/scene_node.h
+++ b/include/xre/scene_node.h
@@ -42,6 +42,11 @@ public:
   void setPosition(float x, float y, float z);
   void setPosition(DirectX::XMVECTOR position);
 
+  // Getters for position, scale and rotation
+  DirectX::XMVECTOR getRotation();
+  DirectX::XMVECTOR getScale();
+  DirectX::XMVECTOR getPosition();
+
   static std::unordered_set<SceneNode*> getGrabbableInstances();
   void setGrabbable(bool grabbable);
 

--- a/include/xre/scene_node.h
+++ b/include/xre/scene_node.h
@@ -106,4 +106,6 @@ private:
   inline static std::unordered_set<SceneNode*> s_grabbable_instances;
 
   inline static std::unordered_set<SceneNode*> s_terrain_instances;
+
+  bool m_transform_needs_update = true;
 };

--- a/include/xre/scene_node.h
+++ b/include/xre/scene_node.h
@@ -47,6 +47,11 @@ public:
 
   bool intersects(DirectX::BoundingOrientedBox other);
 
+  bool m_grabbed = false;
+  bool m_intersected_in_current_frame = false;
+
+  static void resetIntersectedStates();
+
 private:
   // Parent node (which might be null for the root node)
   SceneNode* m_parent;

--- a/include/xre/scene_node.h
+++ b/include/xre/scene_node.h
@@ -65,6 +65,8 @@ public:
 
   static void resetInteractionStates();
 
+  bool m_render = true;
+
 private:
   // Parent node (which might be null for the root node)
   SceneNode* m_parent;

--- a/include/xre/scene_node.h
+++ b/include/xre/scene_node.h
@@ -16,6 +16,8 @@ public:
   SceneNode();
   SceneNode(Model* model);
   SceneNode(Model* model, SceneNode &parent);
+  SceneNode(Renderable* model);
+  SceneNode(Renderable* model, SceneNode &parent);
   ~SceneNode();
 
   void addChildNode(SceneNode &child);
@@ -75,9 +77,10 @@ private:
   // Children of this node
   std::vector<SceneNode *> m_children;
 
-  // Model contained in this node (which might be null, e.g. for a node only containing some
+  // Model or Renderable contained in this node (which might be null, e.g. for a node only containing some
   // transformation)
-  Model* m_model;
+  Model* m_model = nullptr;
+  Renderable* m_renderable = nullptr;
 
   // Position, scale and rotation of the SceneNode. These are all LOCAL,
   // i.e. in relation to the transform of the parent node!

--- a/include/xre/scene_node.h
+++ b/include/xre/scene_node.h
@@ -1,0 +1,55 @@
+#pragma once
+
+// DirectX includes
+#include <d3d11.h>
+#include <DirectXMath/DirectXMath.h>
+
+// XRe includes
+#include <xre/model.h>
+#include <xre/shader.h>
+
+// Other includes
+#include <vector>
+
+class SceneNode {
+public:
+  SceneNode();
+  SceneNode(Model* model);
+  ~SceneNode();
+
+  void addChildNode(SceneNode &child);
+  void render();
+  void updateTransformation();
+
+private:
+  // Parent node (which might be null for the root node)
+  SceneNode* m_parent;
+
+  // Children of this node
+  std::vector<SceneNode *> m_children;
+
+  // Model contained in this node (which might be null, e.g. for a node only containing some
+  // transformation)
+  Model* m_model;
+
+  // TODO: remove when models have a default shader
+  Shader m_shader;
+
+  // Position, scale and rotation of the SceneNode. These are all LOCAL,
+  // i.e. in relation to the transform of the parent node!
+  // Scale factors, initialize to use the scale of 1 for X, Y and Z
+  DirectX::XMVECTOR m_scaling = DirectX::XMVECTORF32({1.0f, 1.0f, 1.0f});
+  // The position of the object in world coordinates
+  DirectX::XMVECTOR m_translation = DirectX::XMVECTORF32({0.0f, 0.0f, 0.0f});
+  // The rotation of the SceneNode
+  DirectX::XMVECTOR m_rotation = DirectX::XMQuaternionIdentity();
+
+  // Transform relative to world coordinates
+  DirectX::XMMATRIX m_world_transform;
+
+  // Transform relative to parent
+  DirectX::XMMATRIX m_local_transform;
+
+  // Rotation relative to world
+  DirectX::XMMATRIX m_world_rotation_matrix;
+};

--- a/include/xre/text.h
+++ b/include/xre/text.h
@@ -7,13 +7,13 @@
 // XRe includes
 #include <xre/structs.h>
 #include <xre/utils.h>
-#include <xre/bitmap.h>
+#include <xre/renderable.h>
 
 // Other includes
 #include <fstream>
 #include <vector>
 
-class Text {
+class Text : public Renderable {
 public:
   Text(const char* sentence);
 
@@ -26,8 +26,6 @@ private:
   // Steps for going through the texture
   const float X_STEP = 1.0f / 32.0f;
   const float Y_STEP = 1.0f / 7.0f;
-
-  Bitmap m_bitmap;
 
   void buildMeshesFromSentence(const char* sentence);
   inline text_char_t computeTextureOffsets(int letter);

--- a/include/xre/text.h
+++ b/include/xre/text.h
@@ -27,6 +27,9 @@ private:
   const float X_STEP = 1.0f / 32.0f;
   const float Y_STEP = 1.0f / 7.0f;
 
+  // Text does not have a bounding box
+  inline bool hasBoundingBox() override { return false; };
+
   void buildMeshesFromSentence(const char* sentence);
   inline text_char_t computeTextureOffsets(int letter);
 };

--- a/include/xre/utils.h
+++ b/include/xre/utils.h
@@ -89,4 +89,8 @@ namespace Utils {
   inline void printVector(DirectX::XMFLOAT4 input) {
     std::cout << input.x << ", " << input.y << ", " << input.z << ", " << input.w << std::endl;
   }
+
+  inline void printVector(DirectX::XMFLOAT3 input) {
+    std::cout << input.x << ", " << input.y << ", " << input.z << std::endl;
+  }
 }

--- a/shaders/fixed_position.hlsl
+++ b/shaders/fixed_position.hlsl
@@ -7,8 +7,8 @@ VOut VShader(VIn input) {
   // Position is simply the input position multiplied by the view projection
   output.position = mul(input.position, view_projection);
 
-  // Simply use white as the color
-	output.color = color_white;
+  // Simply use the model color for the color
+	output.color = model_color;
 
   // No texture coordinates
   output.texcoord = null_texture_coords;

--- a/shaders/fixed_position.hlsl
+++ b/shaders/fixed_position.hlsl
@@ -1,0 +1,22 @@
+#include "_common.hlsl"
+
+// This shader simply uses the input position and does not apply and model transformations
+VOut VShader(VIn input) {
+  VOut output;
+
+  // Position is simply the input position multiplied by the view projection
+  output.position = mul(input.position, view_projection);
+
+  // Simply use white as the color
+	output.color = color_white;
+
+  // No texture coordinates
+  output.texcoord = null_texture_coords;
+
+
+  return output;
+}
+
+float4 PShader(float4 position : SV_POSITION, float4 color : COLOR) : SV_TARGET {
+  return color;
+}

--- a/src/bitmap.cpp
+++ b/src/bitmap.cpp
@@ -48,5 +48,6 @@ void Bitmap::render() {
   m_shader.activate();
   m_shader.setModelColor(m_bitmap_color);
   m_shader.updatePerModelConstantBuffer();
+
   Renderable::render();
 }

--- a/src/bounding_box_mesh.cpp
+++ b/src/bounding_box_mesh.cpp
@@ -1,8 +1,6 @@
 #include <xre/bounding_box_mesh.h>
 
-BoundingBoxMesh::BoundingBoxMesh() {
-
-}
+BoundingBoxMesh::BoundingBoxMesh() {}
 
 BoundingBoxMesh::BoundingBoxMesh(std::vector<vertex_t> vertices) {
   std::vector<unsigned int> bounding_box_indices = {
@@ -17,9 +15,14 @@ BoundingBoxMesh::BoundingBoxMesh(std::vector<vertex_t> vertices) {
 
   createVertexBuffer(vertices, &m_vertex_buffer);
   createIndexBuffer(bounding_box_indices, &m_index_buffer);
+
+  // Set shader to simply use the color shader
+  m_shader = Shader::loadOrCreate(SHADERS_FOLDER "/fixed_position.hlsl");
 }
 
 void BoundingBoxMesh::render() {
+  m_shader.activate();
+
   UINT stride = sizeof(vertex_t);
   UINT offset = 0;
 

--- a/src/bounding_box_mesh.cpp
+++ b/src/bounding_box_mesh.cpp
@@ -23,6 +23,7 @@ BoundingBoxMesh::BoundingBoxMesh(std::vector<vertex_t> vertices) {
 void BoundingBoxMesh::render() {
   m_shader.activate();
   m_shader.setModelColor({1.0f, 1.0f, 1.0f, 1.0f});
+  m_shader.updatePerModelConstantBuffer();
 
   UINT stride = sizeof(vertex_t);
   UINT offset = 0;

--- a/src/bounding_box_mesh.cpp
+++ b/src/bounding_box_mesh.cpp
@@ -22,6 +22,7 @@ BoundingBoxMesh::BoundingBoxMesh(std::vector<vertex_t> vertices) {
 
 void BoundingBoxMesh::render() {
   m_shader.activate();
+  m_shader.setModelColor({1.0f, 1.0f, 1.0f, 1.0f});
 
   UINT stride = sizeof(vertex_t);
   UINT offset = 0;

--- a/src/bounding_box_mesh.cpp
+++ b/src/bounding_box_mesh.cpp
@@ -29,3 +29,21 @@ void BoundingBoxMesh::render() {
   s_device_context->IASetPrimitiveTopology(D3D11_PRIMITIVE_TOPOLOGY_LINELIST);
   s_device_context->DrawIndexed(24, 0, 0);
 }
+
+void BoundingBoxMesh::updateVerticesFromBoundingBox(DirectX::BoundingOrientedBox bounding_box) {
+  // Create the bounding box mesh, such that we can render it
+  DirectX::XMFLOAT3 corners[bounding_box.CORNER_COUNT];
+  bounding_box.GetCorners(corners);
+  std::vector<vertex_t> bounding_box_vertices;
+
+  // Create vertices from the corners of the bounding box
+  for (int i = 0; i < bounding_box.CORNER_COUNT; i++) {
+    bounding_box_vertices.push_back({ corners[i], { 1.0f, 0.0f, 0.0f }, { 0.0f, 0.0f } });
+  }
+
+  // Update the vertex buffer
+  D3D11_MAPPED_SUBRESOURCE resource;
+  s_device_context->Map(m_vertex_buffer, 0, D3D11_MAP_WRITE_DISCARD, 0, &resource);
+  memcpy(resource.pData, bounding_box_vertices.data(), sizeof(vertex_t) * bounding_box_vertices.size());
+  s_device_context->Unmap(m_vertex_buffer, 0);
+}

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -64,37 +64,32 @@ void Controller::updatePosition(DirectX::XMVECTOR current_origin) {
 }
 
 void Controller::computeSceneInteractions() {
+  // Nothing to do if the controller is not active
   if(!m_active) {
     return;
   }
 
   DirectX::BoundingOrientedBox controller_bounding_box = m_model.getTransformedBoundingBox();
 
-  // // Check if any of our controllers is grabbing a grabbable model
-  // for(Model *current_model : Model::getGrabbableInstances()) {
-  //   current_model->setGrabbed(false);
-
-  //   // TODO: maybe set a bit a better indicator that an object is intersecting, e.g. a glow effect
-  //   if(current_model->intersects(controller_bounding_box)) {
-  //     // Set a different color if the controller is intersecting another model
-  //     current_model->setColor({1.0f, 0.0f, 0.0f, 1.0f});
-
-  //     // Also, if the controller is grabbing, set the position and the rotation of the
-  //     // model to those of the controller
-  //     if (m_grabbing) {
-  //       current_model->setGrabbed(true);
-  //       current_model->setPosition(m_model.getPosition());
-  //       current_model->setRotation(m_model.getRotation());
-  //     }
-  //   }
-  //   else {
-  //     current_model->resetColor();
-  //   }
-  // }
-
+  // Check if any of our controllers is grabbing a grabbable node
   for(SceneNode *current_node : SceneNode::getGrabbableInstances()) {
+    // Skip this if we already are intersecting with this node with another controller
+    if (current_node->m_intersected_in_current_frame) {
+      continue;
+    }
+
     if(current_node->intersects(controller_bounding_box)) {
-      std::cout << "Intersect" << std::endl;
+      // TODO: maybe set a bit a better indicator that an object is intersecting, e.g. a glow effect
+      // Set a different color if the controller is intersecting another model
+      current_node->m_intersected_in_current_frame = true;
+
+      // Also, if the controller is grabbing, set the position and the rotation of the
+      // model to those of the controller
+      if (m_grabbing) {
+        current_node->m_grabbed = true;
+        current_node->setPosition(m_model.getPosition());
+        current_node->setRotation(m_model.getRotation());
+      }
     }
   }
 }

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -105,12 +105,12 @@ std::optional<DirectX::XMVECTOR> Controller::updateIntersectionSphereAndComputeP
   }
 
   // Next, check if we need to render the aim intersection sphere
-  m_intersection_sphere_node.m_render = false;
+  m_intersection_sphere_node.setActive(false);
 
   float closest_grabbable_aim_intersection = computeAimIndicatorSpherePosition(SceneNode::getGrabbableInstances());
   float closest_terrain_aim_intersection = computeAimIndicatorSpherePosition(SceneNode::getTerrainInstances());
 
-  if (m_intersection_sphere_node.m_render) {
+  if (m_intersection_sphere_node.isActive()) {
     // The direction vector has unit length, i.e. to stretch it to the required length, we
     // simple multiply the vector with the length, which gives us a new vector.
     DirectX::XMVECTOR stretched_direction = m_aim_line.getLineDirection() * std::min(closest_grabbable_aim_intersection, closest_terrain_aim_intersection);
@@ -148,7 +148,7 @@ float Controller::computeAimIndicatorSpherePosition(std::unordered_set<SceneNode
 
     if(current_node->intersects(m_aim_line.getLineStart(), m_aim_line.getLineDirection(), &intersection_distance)) {
       if (intersection_distance > 0 && intersection_distance <= Controller::s_line_intersection_threshold) {
-        m_intersection_sphere_node.m_render = true;
+        m_intersection_sphere_node.setActive(true);
 
         if (closest_intersection_distance > intersection_distance) {
           closest_intersection_distance = intersection_distance;

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -70,25 +70,31 @@ void Controller::computeSceneInteractions() {
 
   DirectX::BoundingOrientedBox controller_bounding_box = m_model.getTransformedBoundingBox();
 
-  // Check if any of our controllers is grabbing a grabbable model
-  for(Model *current_model : Model::getGrabbableInstances()) {
-    current_model->setGrabbed(false);
+  // // Check if any of our controllers is grabbing a grabbable model
+  // for(Model *current_model : Model::getGrabbableInstances()) {
+  //   current_model->setGrabbed(false);
 
-    // TODO: maybe set a bit a better indicator that an object is intersecting, e.g. a glow effect
-    if(current_model->intersects(controller_bounding_box)) {
-      // Set a different color if the controller is intersecting another model
-      current_model->setColor({1.0f, 0.0f, 0.0f, 1.0f});
+  //   // TODO: maybe set a bit a better indicator that an object is intersecting, e.g. a glow effect
+  //   if(current_model->intersects(controller_bounding_box)) {
+  //     // Set a different color if the controller is intersecting another model
+  //     current_model->setColor({1.0f, 0.0f, 0.0f, 1.0f});
 
-      // Also, if the controller is grabbing, set the position and the rotation of the
-      // model to those of the controller
-      if (m_grabbing) {
-        current_model->setGrabbed(true);
-        current_model->setPosition(m_model.getPosition());
-        current_model->setRotation(m_model.getRotation());
-      }
-    }
-    else {
-      current_model->resetColor();
+  //     // Also, if the controller is grabbing, set the position and the rotation of the
+  //     // model to those of the controller
+  //     if (m_grabbing) {
+  //       current_model->setGrabbed(true);
+  //       current_model->setPosition(m_model.getPosition());
+  //       current_model->setRotation(m_model.getRotation());
+  //     }
+  //   }
+  //   else {
+  //     current_model->resetColor();
+  //   }
+  // }
+
+  for(SceneNode *current_node : SceneNode::getGrabbableInstances()) {
+    if(current_node->intersects(controller_bounding_box)) {
+      std::cout << "Intersect" << std::endl;
     }
   }
 }

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -18,7 +18,6 @@ Controller::Controller() {
 
   // Create the shaders for the controller
   m_controller_shader = Shader::loadOrCreate(SHADERS_FOLDER "/ambient.hlsl");
-  m_aim_indicator_shader = Shader::loadOrCreate(SHADERS_FOLDER "/color.hlsl");
 
   // Create the line for the aim direction
   m_aim_line = Line({0.0f, 0.0f, 0.0f}, {0.0f, 0.0f, 1.0f});
@@ -43,11 +42,6 @@ void Controller::render() {
 
   // Render the aim line
   m_aim_line.render(m_controller_shader);
-
-  // Render the aim interaction sphere
-  if (m_render_intersection_sphere) {
-    m_aim_indicator_sphere.render(m_aim_indicator_shader);
-  }
 }
 
 void Controller::updatePosition(DirectX::XMVECTOR current_origin) {
@@ -111,12 +105,12 @@ std::optional<DirectX::XMVECTOR> Controller::updateIntersectionSphereAndComputeP
   }
 
   // Next, check if we need to render the aim intersection sphere
-  m_render_intersection_sphere = false;
+  m_intersection_sphere_node.m_render = false;
 
   float closest_grabbable_aim_intersection = computeAimIndicatorSpherePosition(SceneNode::getGrabbableInstances());
   float closest_terrain_aim_intersection = computeAimIndicatorSpherePosition(SceneNode::getTerrainInstances());
 
-  if (m_render_intersection_sphere) {
+  if (m_intersection_sphere_node.m_render) {
     // The direction vector has unit length, i.e. to stretch it to the required length, we
     // simple multiply the vector with the length, which gives us a new vector.
     DirectX::XMVECTOR stretched_direction = m_aim_line.getLineDirection() * std::min(closest_grabbable_aim_intersection, closest_terrain_aim_intersection);
@@ -154,7 +148,7 @@ float Controller::computeAimIndicatorSpherePosition(std::unordered_set<SceneNode
 
     if(current_node->intersects(m_aim_line.getLineStart(), m_aim_line.getLineDirection(), &intersection_distance)) {
       if (intersection_distance > 0 && intersection_distance <= Controller::s_line_intersection_threshold) {
-        m_render_intersection_sphere = true;
+        m_intersection_sphere_node.m_render = true;
 
         if (closest_intersection_distance > intersection_distance) {
           closest_intersection_distance = intersection_distance;

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -16,11 +16,10 @@ Controller::Controller() {
   m_root_node.addChildNode(m_model_node);
   m_root_node.addChildNode(m_intersection_sphere_node);
 
-  // Create the shaders for the controller
-  m_controller_shader = Shader::loadOrCreate(SHADERS_FOLDER "/ambient.hlsl");
-
   // Create the line for the aim direction
   m_aim_line = Line({0.0f, 0.0f, 0.0f}, {0.0f, 0.0f, 1.0f});
+  m_aim_line_node = SceneNode(&m_aim_line);
+  m_root_node.addChildNode(m_aim_line_node);
 }
 
 void Controller::render() {
@@ -39,9 +38,6 @@ void Controller::render() {
   }
 
   m_root_node.render();
-
-  // Render the aim line
-  m_aim_line.render();
 }
 
 void Controller::updatePosition(DirectX::XMVECTOR current_origin) {

--- a/src/controller.cpp
+++ b/src/controller.cpp
@@ -41,7 +41,7 @@ void Controller::render() {
   m_root_node.render();
 
   // Render the aim line
-  m_aim_line.render(m_controller_shader);
+  m_aim_line.render();
 }
 
 void Controller::updatePosition(DirectX::XMVECTOR current_origin) {

--- a/src/line.cpp
+++ b/src/line.cpp
@@ -10,6 +10,9 @@ Line::Line(DirectX::XMFLOAT4 color) {
   // Set buffers to be dynamic, such that their contents can be updated
   m_static_buffers = false;
 
+  // Set shader to simply use the color shader
+  m_shader = Shader::loadOrCreate(SHADERS_FOLDER "/fixed_position.hlsl");
+
   initialize(vertices, indices);
 }
 
@@ -23,22 +26,18 @@ Line::Line(DirectX::XMFLOAT3 line_start, DirectX::XMFLOAT3 line_end, DirectX::XM
   // Set buffers to be dynamic, such that their contents can be updated
   m_static_buffers = false;
 
+  // Set shader to simply use the color shader
+  m_shader = Shader::loadOrCreate(SHADERS_FOLDER "/fixed_position.hlsl");
+
   initialize(vertices, indices);
 }
 
 void Line::render() {
-  // Get the current active shader
-  Shader shader = *Shader::getCurrentActiveShader();
-  render(shader);
-}
-
-void Line::render(Shader &shader) {
   // Activate the shader
-  shader.activate();
+  m_shader.activate();
 
-  shader.setModelMatrix(DirectX::XMMatrixIdentity());
-  shader.setModelColor(m_line_color);
-  shader.updatePerModelConstantBuffer();
+  m_shader.setModelColor(m_line_color);
+  m_shader.updatePerModelConstantBuffer();
 
   // Set vertex and index buffers on the GPU to be the ones of this line
   UINT stride = sizeof(vertex_t);

--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -50,27 +50,3 @@ Mesh::Mesh(std::vector<vertex_t> vertices, std::vector<unsigned int> indices, co
   error_string += texture_path;
   Utils::checkHresult(result, error_string.c_str());
 }
-
-void Mesh::render() {
-  // Set vertex and index buffers on the GPU to be the ones of this mesh
-  UINT stride = sizeof(vertex_t);
-  UINT offset = 0;
-  s_device_context->IASetVertexBuffers(0, 1, &m_vertex_buffer, &stride, &offset);
-  s_device_context->IASetIndexBuffer(m_index_buffer, DXGI_FORMAT_R32_UINT, 0);
-
-  // Set the texture if it exists, otherwise remove any previously added textures
-  if (m_texture_view) {
-    s_device_context->PSSetShaderResources(0, 1, &m_texture_view);
-  }
-  else {
-    s_device_context->PSSetShaderResources(0, 1, &s_nulltexture);
-  }
-
-  // We'll be rendering a triangle list, so we need to tell the GPU
-  // to render the vertices as such.
-  s_device_context->IASetPrimitiveTopology(D3D11_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
-
-  // And finally, we can call the actual draw method, which will draw all the
-  // indices of this mesh.
-  s_device_context->DrawIndexed(m_index_count, 0, 0);
-}

--- a/src/model.cpp
+++ b/src/model.cpp
@@ -18,12 +18,14 @@ Model::Model(std::vector<Mesh> meshes, DirectX::XMFLOAT4 color) {
   m_meshes = meshes;
   m_model_color = color;
   m_original_model_color = color;
+  m_shader = Shader::loadOrCreate(SHADERS_FOLDER "/ambient.hlsl");
 }
 
 Model::Model(const char *model_path, DirectX::XMFLOAT4 color) {
   loadObj(model_path);
   m_model_color = color;
   m_original_model_color = color;
+  m_shader = Shader::loadOrCreate(SHADERS_FOLDER "/ambient.hlsl");
 }
 
 void Model::render() {

--- a/src/model.cpp
+++ b/src/model.cpp
@@ -37,19 +37,28 @@ Model::Model(const char *model_path, DirectX::XMFLOAT4 color, const char* shader
 }
 
 void Model::render() {
+  if (m_has_transparency) {
+    renderWithTransparency();
+  }
+  else {
+    renderMeshes();
+  }
+}
+
+void Model::renderMeshes() {
   for (Mesh &mesh : m_meshes) {
     mesh.render();
   }
 }
 
-void Model::renderTransparent() {
+void Model::renderWithTransparency() {
   // Render the model twice, once with Counterclockwise
   // cull mode, once with the normal clockwise cull mode, such
   // that the transparency works correctly.
   s_dx11_handler->useDefaultRasterizer(false);
-  render();
+  renderMeshes();
   s_dx11_handler->useDefaultRasterizer(true);
-  render();
+  renderMeshes();
 }
 
 void Model::setColor(DirectX::XMFLOAT4 color) {

--- a/src/model.cpp
+++ b/src/model.cpp
@@ -27,114 +27,19 @@ Model::Model(const char *model_path, DirectX::XMFLOAT4 color) {
 }
 
 void Model::render() {
-  // Get the current active shader
-  Shader shader = *Shader::getCurrentActiveShader();
-  render(shader);
-}
-
-void Model::renderInSceneNode() {
   for (Mesh &mesh : m_meshes) {
     mesh.render();
   }
 }
 
-void Model::render(Shader &shader) {
-  // Activate the shader
-  shader.activate();
-
-  // Update the shader with the model matrix
-  shader.setModelMatrix(getTransformationMatrix());
-  shader.setNormalRotationMatrix(getRotationMatrix());
-  shader.setModelColor(m_model_color);
-  shader.updatePerModelConstantBuffer();
-
-  for (Mesh &mesh : m_meshes) {
-    mesh.render();
-  }
-}
-
-void Model::renderTransparent(Shader &shader) {
+void Model::renderTransparent() {
   // Render the model twice, once with Counterclockwise
   // cull mode, once with the normal clockwise cull mode, such
   // that the transparency works correctly.
   s_dx11_handler->useDefaultRasterizer(false);
-  render(shader);
+  render();
   s_dx11_handler->useDefaultRasterizer(true);
-  render(shader);
-}
-
-DirectX::XMMATRIX Model::getTransformationMatrix() {
-  return DirectX::XMMatrixTranspose(DirectX::XMMatrixAffineTransformation(
-         m_scaling,
-         DirectX::g_XMZero,
-         m_rotation,
-         m_translation));
-
-}
-
-DirectX::XMMATRIX Model::getRotationMatrix() {
-  return DirectX::XMMatrixRotationQuaternion(m_rotation);
-}
-
-void Model::rotate(float roll, float pitch, float yaw) {
-  DirectX::XMVECTOR rotation = DirectX::XMQuaternionRotationRollPitchYaw(pitch, yaw, roll);
-  rotate(rotation);
-}
-
-void Model::rotate(DirectX::XMVECTOR rotation) {
-  m_rotation = DirectX::XMQuaternionMultiply(m_rotation, rotation);
-}
-
-void Model::translate(float x, float y, float z) {
-  DirectX::XMVECTOR translation = DirectX::XMVECTORF32({x, y, z});
-  translate(translation);
-}
-
-void Model::translate(DirectX::XMVECTOR translation) {
-  m_translation = DirectX::XMVectorAdd(m_translation, translation);
-}
-
-void Model::scale(float x, float y, float z) {
-  DirectX::XMVECTOR scaling = DirectX::XMVECTORF32({x, y, z});
-  scale(scaling);
-}
-
-void Model::scale(DirectX::XMVECTOR scaling) {
-  m_scaling = DirectX::XMVectorMultiply(m_scaling, scaling);
-}
-
-void Model::setRotation(DirectX::XMVECTOR rotation) {
-  m_rotation = rotation;
-}
-
-void Model::setScale(float x, float y, float z) {
-  DirectX::XMVECTOR scaling = DirectX::XMVECTORF32({x, y, z});
-  setScale(scaling);
-}
-
-void Model::setScale(DirectX::XMVECTOR scaling) {
-  m_scaling = scaling;
-}
-
-void Model::setPosition(float x, float y, float z) {
-  DirectX::XMVECTOR position = DirectX::XMVECTORF32({x, y, z});
-  setPosition(position);
-}
-
-void Model::setPosition(DirectX::XMVECTOR position) {
-  m_translation = position;
-}
-
-DirectX::XMVECTOR Model::getRotation() {
-  return m_rotation;
-}
-
-DirectX::XMVECTOR Model::getScale() {
-  return m_scaling;
-}
-
-DirectX::XMVECTOR Model::getPosition() {
-  return m_translation;
+  render();
 }
 
 void Model::setColor(DirectX::XMFLOAT4 color) {

--- a/src/model.cpp
+++ b/src/model.cpp
@@ -316,37 +316,3 @@ DirectX::BoundingOrientedBox Model::applyTransformToBoundingBox(DirectX::Boundin
   // Done
   return transformed;
 }
-
-void Model::setGrabbable(bool grabbable) {
-  if (grabbable) {
-    Model::s_grabbable_instances.insert(this);
-  }
-  else {
-    Model::s_grabbable_instances.erase(this);
-  }
-}
-
-void Model::setGrabbed(bool grabbed) {
-  m_grabbed = grabbed;
-}
-
-bool Model::getGrabbed() {
-  return m_grabbed;
-}
-
-std::unordered_set<Model*> Model::getGrabbableInstances() {
-  return s_grabbable_instances;
-}
-
-void Model::setIsTerrain(bool is_terrain) {
-  if (is_terrain) {
-    Model::s_terrain_instances.insert(this);
-  }
-  else {
-    Model::s_terrain_instances.erase(this);
-  }
-}
-
-std::unordered_set<Model*> Model::getTerrainInstances() {
-  return s_terrain_instances;
-}

--- a/src/model.cpp
+++ b/src/model.cpp
@@ -37,9 +37,9 @@ void Model::render() {
 }
 
 void Model::renderInSceneNode() {
-  for (Mesh &mesh : m_meshes) {
-    mesh.render();
-  }
+  // for (Mesh &mesh : m_meshes) {
+  //   mesh.render();
+  // }
 
   // Next, render the bounding box
   m_bounding_box_mesh.render();

--- a/src/model.cpp
+++ b/src/model.cpp
@@ -55,9 +55,6 @@ void Model::render(Shader &shader) {
   for (Mesh &mesh : m_meshes) {
     mesh.render();
   }
-
-  // Next, render the bounding box
-  m_bounding_box_mesh.render();
 }
 
 void Model::renderTransparent(Shader &shader) {
@@ -264,8 +261,6 @@ void Model::buildBoundingBox() {
   for (int i = 0; i < m_bounding_box.CORNER_COUNT; i++) {
     bounding_box_vertices.push_back({ corners[i], { 1.0f, 0.0f, 0.0f }, { 0.0f, 0.0f } });
   }
-
-  m_bounding_box_mesh = BoundingBoxMesh(bounding_box_vertices);
 }
 
 bool Model::intersects(DirectX::BoundingOrientedBox other) {

--- a/src/model.cpp
+++ b/src/model.cpp
@@ -42,7 +42,7 @@ void Model::renderInSceneNode() {
   // }
 
   // Next, render the bounding box
-  m_bounding_box_mesh.render();
+  // m_bounding_box_mesh.render();
 }
 
 void Model::render(Shader &shader) {
@@ -233,10 +233,9 @@ void Model::registerDx11Handler(Dx11Handler *handler) {
   Model::s_dx11_handler = handler;
 }
 
-void Model::buildBoundingBox() {
+std::vector<DirectX::XMFLOAT3> Model::getMeshBoundingBoxCorners() {
   size_t points_count = m_meshes.size() * 8;
-  DirectX::XMFLOAT3 all_corners[points_count];
-  size_t idx = 0;
+  std::vector<DirectX::XMFLOAT3> all_corners;
 
   // Get all bounding boxes of all meshes, and put the
   // corners into the previously defined array
@@ -245,12 +244,19 @@ void Model::buildBoundingBox() {
     mesh.getBoundingBox().GetCorners(corners);
 
     for (size_t j = 0; j < 8; j++) {
-      all_corners[idx++] = corners[j];
+     all_corners.push_back(corners[j]);
     }
   }
 
+  return all_corners;
+}
+
+void Model::buildBoundingBox() {
+  std::vector<DirectX::XMFLOAT3> bounding_box_corners = getMeshBoundingBoxCorners();
+  size_t points_count = bounding_box_corners.size();
+
   // Build the bounding box
-  DirectX::BoundingOrientedBox::CreateFromPoints(m_bounding_box, points_count, all_corners, sizeof(DirectX::XMFLOAT3));
+  DirectX::BoundingOrientedBox::CreateFromPoints(m_bounding_box, points_count, bounding_box_corners.data(), sizeof(DirectX::XMFLOAT3));
 
   // Create the bounding box mesh, such that we can render it
   DirectX::XMFLOAT3 corners[m_bounding_box.CORNER_COUNT];

--- a/src/model.cpp
+++ b/src/model.cpp
@@ -36,6 +36,15 @@ void Model::render() {
   render(shader);
 }
 
+void Model::renderInSceneNode() {
+  for (Mesh &mesh : m_meshes) {
+    mesh.render();
+  }
+
+  // Next, render the bounding box
+  m_bounding_box_mesh.render();
+}
+
 void Model::render(Shader &shader) {
   // Activate the shader
   shader.activate();
@@ -144,6 +153,10 @@ void Model::setColor(DirectX::XMFLOAT4 color) {
 
 void Model::resetColor() {
   m_model_color = m_original_model_color;
+}
+
+DirectX::XMFLOAT4 Model::getColor() {
+  return m_model_color;
 }
 
 void Model::loadObj(const char *model_path) {

--- a/src/model.cpp
+++ b/src/model.cpp
@@ -37,12 +37,9 @@ void Model::render() {
 }
 
 void Model::renderInSceneNode() {
-  // for (Mesh &mesh : m_meshes) {
-  //   mesh.render();
-  // }
-
-  // Next, render the bounding box
-  // m_bounding_box_mesh.render();
+  for (Mesh &mesh : m_meshes) {
+    mesh.render();
+  }
 }
 
 void Model::render(Shader &shader) {

--- a/src/model.cpp
+++ b/src/model.cpp
@@ -14,18 +14,26 @@ Model::Model() {}
 //  1) Vector of meshes for this model
 //  2) Color of the model
 //------------------------------------------------------------------------------------------------------
-Model::Model(std::vector<Mesh> meshes, DirectX::XMFLOAT4 color) {
+Model::Model(std::vector<Mesh> meshes) : Model::Model(meshes, DirectX::XMFLOAT4(0.8f, 0.8f, 0.8f, 1.0f), SHADERS_FOLDER "/ambient.hlsl") {}
+Model::Model(std::vector<Mesh> meshes, DirectX::XMFLOAT4 color) : Model::Model(meshes, color, SHADERS_FOLDER "/ambient.hlsl") {}
+Model::Model(std::vector<Mesh> meshes, const char* shader_path) : Model::Model(meshes, DirectX::XMFLOAT4(0.8f, 0.8f, 0.8f, 1.0f), shader_path) {}
+
+Model::Model(std::vector<Mesh> meshes, DirectX::XMFLOAT4 color, const char* shader_path) {
   m_meshes = meshes;
   m_model_color = color;
   m_original_model_color = color;
-  m_shader = Shader::loadOrCreate(SHADERS_FOLDER "/ambient.hlsl");
+  m_shader = Shader::loadOrCreate(shader_path);
 }
 
-Model::Model(const char *model_path, DirectX::XMFLOAT4 color) {
+Model::Model(const char *model_path) : Model::Model(model_path, DirectX::XMFLOAT4(0.8f, 0.8f, 0.8f, 1.0f), SHADERS_FOLDER "/ambient.hlsl") {}
+Model::Model(const char *model_path, DirectX::XMFLOAT4 color) : Model::Model(model_path, color, SHADERS_FOLDER "/ambient.hlsl") {}
+Model::Model(const char *model_path, const char* shader_path) : Model::Model(model_path, DirectX::XMFLOAT4(0.8f, 0.8f, 0.8f, 1.0f), shader_path) {}
+
+Model::Model(const char *model_path, DirectX::XMFLOAT4 color, const char* shader_path) {
   loadObj(model_path);
   m_model_color = color;
   m_original_model_color = color;
-  m_shader = Shader::loadOrCreate(SHADERS_FOLDER "/ambient.hlsl");
+  m_shader = Shader::loadOrCreate(shader_path);
 }
 
 void Model::render() {

--- a/src/openxr_handler.cpp
+++ b/src/openxr_handler.cpp
@@ -775,6 +775,9 @@ void OpenXrHandler::renderFrame(std::function<void()> draw_callback, std::functi
   teleport_location_left = m_left_controller->updateIntersectionSphereAndComputePossibleTeleport();
   teleport_location_right = m_right_controller->updateIntersectionSphereAndComputePossibleTeleport();
 
+  // Reset the "m_intersected_in_current_frame" booleans on the grabbable SceneNodes
+  SceneNode::resetIntersectedStates();
+
   // As both might have a value, we arbitrarily decide to give the right controller
   // precedende. Later, we might map the teleport action to a single controller anyway,
   // so maybe this will not be needed anymore.

--- a/src/openxr_handler.cpp
+++ b/src/openxr_handler.cpp
@@ -698,6 +698,8 @@ void OpenXrHandler::updateControllerStates(Controller *controller, XrTime predic
 void OpenXrHandler::updateHandTrackingStates(Hand *hand, XrTime predicted_time) {
   XrResult result;
 
+  return;
+
   // Return if the runtime does not support hand tracking
   if (!m_openxr_hand_tracking_system_properties.supportsHandTracking) {
     return;
@@ -979,6 +981,9 @@ XrPath OpenXrHandler::getXrPathFromString(std::string string) {
 
 void OpenXrHandler::initializeHandTracking() {
   XrResult result;
+
+  // Disable for now
+  return;
 
   // Return if the runtime does not support hand tracking
   if (!m_openxr_hand_tracking_system_properties.supportsHandTracking) {

--- a/src/openxr_handler.cpp
+++ b/src/openxr_handler.cpp
@@ -698,8 +698,6 @@ void OpenXrHandler::updateControllerStates(Controller *controller, XrTime predic
 void OpenXrHandler::updateHandTrackingStates(Hand *hand, XrTime predicted_time) {
   XrResult result;
 
-  return;
-
   // Return if the runtime does not support hand tracking
   if (!m_openxr_hand_tracking_system_properties.supportsHandTracking) {
     return;
@@ -775,8 +773,8 @@ void OpenXrHandler::renderFrame(std::function<void()> draw_callback, std::functi
   teleport_location_left = m_left_controller->updateIntersectionSphereAndComputePossibleTeleport();
   teleport_location_right = m_right_controller->updateIntersectionSphereAndComputePossibleTeleport();
 
-  // Reset the "m_intersected_in_current_frame" booleans on the grabbable SceneNodes
-  SceneNode::resetIntersectedStates();
+  // Reset the interaction tracking booleans on the grabbable SceneNodes
+  SceneNode::resetInteractionStates();
 
   // As both might have a value, we arbitrarily decide to give the right controller
   // precedende. Later, we might map the teleport action to a single controller anyway,
@@ -984,9 +982,6 @@ XrPath OpenXrHandler::getXrPathFromString(std::string string) {
 
 void OpenXrHandler::initializeHandTracking() {
   XrResult result;
-
-  // Disable for now
-  return;
 
   // Return if the runtime does not support hand tracking
   if (!m_openxr_hand_tracking_system_properties.supportsHandTracking) {

--- a/src/renderable.cpp
+++ b/src/renderable.cpp
@@ -75,3 +75,26 @@ DirectX::BoundingOrientedBox Renderable::getBoundingBox() {
   return m_bounding_box;
 }
 
+void Renderable::render() {
+  // Set vertex and index buffers on the GPU to be the ones of this mesh
+  UINT stride = sizeof(vertex_t);
+  UINT offset = 0;
+  s_device_context->IASetVertexBuffers(0, 1, &m_vertex_buffer, &stride, &offset);
+  s_device_context->IASetIndexBuffer(m_index_buffer, DXGI_FORMAT_R32_UINT, 0);
+
+  // Set the texture if it exists, otherwise remove any previously added textures
+  if (m_texture_view) {
+    s_device_context->PSSetShaderResources(0, 1, &m_texture_view);
+  }
+  else {
+    s_device_context->PSSetShaderResources(0, 1, &s_nulltexture);
+  }
+
+  // We'll be rendering a triangle list, so we need to tell the GPU
+  // to render the vertices as such.
+  s_device_context->IASetPrimitiveTopology(D3D11_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
+
+  // And finally, we can call the actual draw method, which will draw all the
+  // indices of this mesh.
+  s_device_context->DrawIndexed(m_index_count, 0, 0);
+}

--- a/src/scene.cpp
+++ b/src/scene.cpp
@@ -1,5 +1,0 @@
-#include <xre/scene.h>
-
-void Scene::render() {
-
-}

--- a/src/scene_node.cpp
+++ b/src/scene_node.cpp
@@ -47,6 +47,10 @@ void SceneNode::addChildNode(SceneNode *child) {
 }
 
 void SceneNode::render() {
+  if (!m_render) {
+    return;
+  }
+
   if (m_model) {
     m_shader.activate();
 
@@ -60,7 +64,7 @@ void SceneNode::render() {
       m_shader.setModelColor(m_model->getColor());
     }
     m_shader.updatePerModelConstantBuffer();
-    m_model->renderInSceneNode();
+    m_model->render();
 
     // Set shader variables to identities, as the bounding box is already updated
     // with the correct position (as we need the correct position to be able to

--- a/src/scene_node.cpp
+++ b/src/scene_node.cpp
@@ -46,7 +46,7 @@ void SceneNode::addChildNode(SceneNode *child) {
 }
 
 void SceneNode::render() {
-  if (!m_render) {
+  if (!m_is_active) {
     return;
   }
 
@@ -210,7 +210,15 @@ void SceneNode::setGrabbable(bool grabbable) {
 }
 
 std::unordered_set<SceneNode*> SceneNode::getGrabbableInstances() {
-  return s_grabbable_instances;
+  std::unordered_set<SceneNode*> result;
+
+  for (SceneNode *current_node : s_grabbable_instances) {
+    if (current_node->isActive()) {
+      result.insert(current_node);
+    }
+  }
+
+  return result;
 }
 
 void SceneNode::setIsTerrain(bool is_terrain) {
@@ -222,8 +230,24 @@ void SceneNode::setIsTerrain(bool is_terrain) {
   }
 }
 
+void SceneNode::setActive(bool is_active) {
+  m_is_active = is_active;
+}
+
+bool SceneNode::isActive() {
+  return m_is_active;
+}
+
 std::unordered_set<SceneNode*> SceneNode::getTerrainInstances() {
-  return s_terrain_instances;
+  std::unordered_set<SceneNode*> result;
+
+  for (SceneNode *current_node : s_terrain_instances) {
+    if (current_node->isActive()) {
+      result.insert(current_node);
+    }
+  }
+
+  return result;
 }
 
 bool SceneNode::intersects(DirectX::BoundingOrientedBox other) {

--- a/src/scene_node.cpp
+++ b/src/scene_node.cpp
@@ -97,7 +97,7 @@ void SceneNode::updateTransformation() {
 
 DirectX::BoundingOrientedBox SceneNode::getTransformedBoundingBox() {
   DirectX::BoundingOrientedBox transformed;
-  m_model_bounding_box.Transform(transformed, m_world_transform);
+  m_model_bounding_box.Transform(transformed, DirectX::XMMatrixTranspose(m_world_transform));
   return transformed;
 }
 

--- a/src/scene_node.cpp
+++ b/src/scene_node.cpp
@@ -49,7 +49,12 @@ void SceneNode::render() {
     // Update the shader with the transform
     m_shader.setModelMatrix(m_world_transform);
     m_shader.setNormalRotationMatrix(m_world_rotation_matrix);
-    m_shader.setModelColor(m_model->getColor());
+    if (m_intersected_in_current_frame) {
+      m_shader.setModelColor({1.0f, 0.0f, 0.0f, 1.0f});
+    }
+    else {
+      m_shader.setModelColor(m_model->getColor());
+    }
     m_shader.updatePerModelConstantBuffer();
     m_model->renderInSceneNode();
 
@@ -176,4 +181,10 @@ std::unordered_set<SceneNode*> SceneNode::getGrabbableInstances() {
 
 bool SceneNode::intersects(DirectX::BoundingOrientedBox other) {
   return getTransformedBoundingBox().Intersects(other);
+}
+
+void SceneNode::resetIntersectedStates() {
+  for (SceneNode* current_node : s_grabbable_instances) {
+    current_node->m_intersected_in_current_frame = false;
+  }
 }

--- a/src/scene_node.cpp
+++ b/src/scene_node.cpp
@@ -3,14 +3,13 @@
 SceneNode::SceneNode() {
   m_parent = NULL;
   m_model = NULL;
-  m_shader = Shader::loadOrCreate(SHADERS_FOLDER "/color.hlsl");
 }
 
 SceneNode::SceneNode(Model* model) {
   m_model = model;
   buildBoundingBox();
   m_parent = NULL;
-  m_shader = Shader::loadOrCreate(SHADERS_FOLDER "/color.hlsl");
+  m_shader = Shader::loadOrCreate(SHADERS_FOLDER "/ambient.hlsl");
 }
 
 void SceneNode::buildBoundingBox() {
@@ -43,9 +42,9 @@ void SceneNode::addChildNode(SceneNode &child) {
 }
 
 void SceneNode::render() {
-  m_shader.activate();
-
   if (m_model) {
+    m_shader.activate();
+
     // Update the shader with the transform
     m_shader.setModelMatrix(m_world_transform);
     m_shader.setNormalRotationMatrix(m_world_rotation_matrix);
@@ -164,6 +163,18 @@ void SceneNode::setPosition(float x, float y, float z) {
 
 void SceneNode::setPosition(DirectX::XMVECTOR position) {
   m_translation = position;
+}
+
+DirectX::XMVECTOR SceneNode::getRotation() {
+  return m_rotation;
+}
+
+DirectX::XMVECTOR SceneNode::getScale() {
+  return m_scaling;
+}
+
+DirectX::XMVECTOR SceneNode::getPosition() {
+  return m_translation;
 }
 
 void SceneNode::setGrabbable(bool grabbable) {

--- a/src/scene_node.cpp
+++ b/src/scene_node.cpp
@@ -149,3 +149,16 @@ void SceneNode::setPosition(float x, float y, float z) {
 void SceneNode::setPosition(DirectX::XMVECTOR position) {
   m_translation = position;
 }
+
+void SceneNode::setGrabbable(bool grabbable) {
+  if (grabbable) {
+    SceneNode::s_grabbable_instances.insert(this);
+  }
+  else {
+    SceneNode::s_grabbable_instances.erase(this);
+  }
+}
+
+std::unordered_set<SceneNode*> SceneNode::getGrabbableInstances() {
+  return s_grabbable_instances;
+}

--- a/src/scene_node.cpp
+++ b/src/scene_node.cpp
@@ -95,6 +95,12 @@ void SceneNode::updateTransformation() {
   }
 }
 
+DirectX::BoundingOrientedBox SceneNode::getTransformedBoundingBox() {
+  DirectX::BoundingOrientedBox transformed;
+  m_model_bounding_box.Transform(transformed, m_world_transform);
+  return transformed;
+}
+
 void SceneNode::rotate(float roll, float pitch, float yaw) {
   DirectX::XMVECTOR rotation = DirectX::XMQuaternionRotationRollPitchYaw(pitch, yaw, roll);
   rotate(rotation);

--- a/src/scene_node.cpp
+++ b/src/scene_node.cpp
@@ -23,14 +23,14 @@ void SceneNode::addChildNode(SceneNode &child) {
 
 void SceneNode::render() {
   m_shader.activate();
-  // TODO: remove `m_shader` param when models have a default shader
+
   if (m_model) {
     // Update the shader with the transform
     m_shader.setModelMatrix(m_world_transform);
     m_shader.setNormalRotationMatrix(m_world_rotation_matrix);
-    // m_shader.setModelColor(m_model->getColor());
+    m_shader.setModelColor(m_model->getColor());
     m_shader.updatePerModelConstantBuffer();
-    m_model->render(m_shader);
+    m_model->renderInSceneNode();
   }
 
   for (SceneNode *child : m_children) {
@@ -70,4 +70,53 @@ void SceneNode::updateTransformation() {
   for (SceneNode *child : m_children) {
     child->updateTransformation();
   }
+}
+
+void SceneNode::rotate(float roll, float pitch, float yaw) {
+  DirectX::XMVECTOR rotation = DirectX::XMQuaternionRotationRollPitchYaw(pitch, yaw, roll);
+  rotate(rotation);
+}
+
+void SceneNode::rotate(DirectX::XMVECTOR rotation) {
+  m_rotation = DirectX::XMQuaternionMultiply(m_rotation, rotation);
+}
+
+void SceneNode::translate(float x, float y, float z) {
+  DirectX::XMVECTOR translation = DirectX::XMVECTORF32({x, y, z});
+  translate(translation);
+}
+
+void SceneNode::translate(DirectX::XMVECTOR translation) {
+  m_translation = DirectX::XMVectorAdd(m_translation, translation);
+}
+
+void SceneNode::scale(float x, float y, float z) {
+  DirectX::XMVECTOR scaling = DirectX::XMVECTORF32({x, y, z});
+  scale(scaling);
+}
+
+void SceneNode::scale(DirectX::XMVECTOR scaling) {
+  m_scaling = DirectX::XMVectorMultiply(m_scaling, scaling);
+}
+
+void SceneNode::setRotation(DirectX::XMVECTOR rotation) {
+  m_rotation = rotation;
+}
+
+void SceneNode::setScale(float x, float y, float z) {
+  DirectX::XMVECTOR scaling = DirectX::XMVECTORF32({x, y, z});
+  setScale(scaling);
+}
+
+void SceneNode::setScale(DirectX::XMVECTOR scaling) {
+  m_scaling = scaling;
+}
+
+void SceneNode::setPosition(float x, float y, float z) {
+  DirectX::XMVECTOR position = DirectX::XMVECTORF32({x, y, z});
+  setPosition(position);
+}
+
+void SceneNode::setPosition(DirectX::XMVECTOR position) {
+  m_translation = position;
 }

--- a/src/scene_node.cpp
+++ b/src/scene_node.cpp
@@ -190,12 +190,30 @@ std::unordered_set<SceneNode*> SceneNode::getGrabbableInstances() {
   return s_grabbable_instances;
 }
 
+void SceneNode::setIsTerrain(bool is_terrain) {
+  if (is_terrain) {
+    SceneNode::s_terrain_instances.insert(this);
+  }
+  else {
+    SceneNode::s_terrain_instances.erase(this);
+  }
+}
+
+std::unordered_set<SceneNode*> SceneNode::getTerrainInstances() {
+  return s_terrain_instances;
+}
+
 bool SceneNode::intersects(DirectX::BoundingOrientedBox other) {
   return getTransformedBoundingBox().Intersects(other);
 }
 
-void SceneNode::resetIntersectedStates() {
+bool SceneNode::intersects(DirectX::XMVECTOR line_start, DirectX::XMVECTOR line_direction, float *out_distance) {
+  return getTransformedBoundingBox().Intersects(line_start, line_direction, *out_distance);
+}
+
+void SceneNode::resetInteractionStates() {
   for (SceneNode* current_node : s_grabbable_instances) {
     current_node->m_intersected_in_current_frame = false;
+    current_node->m_grabbed = false;
   }
 }

--- a/src/scene_node.cpp
+++ b/src/scene_node.cpp
@@ -11,6 +11,12 @@ SceneNode::SceneNode(Model* model) {
   m_parent = NULL;
 }
 
+SceneNode::SceneNode(Model* model, SceneNode &parent) {
+  m_model = model;
+  buildBoundingBox();
+  parent.addChildNode(this);
+}
+
 void SceneNode::buildBoundingBox() {
   std::vector<DirectX::XMFLOAT3> bounding_box_corners = m_model->getMeshBoundingBoxCorners();
   size_t points_count = bounding_box_corners.size();

--- a/src/scene_node.cpp
+++ b/src/scene_node.cpp
@@ -53,6 +53,13 @@ void SceneNode::render() {
     m_shader.updatePerModelConstantBuffer();
     m_model->renderInSceneNode();
 
+    // Set shader variables to identities, as the bounding box is already updated
+    // with the correct position (as we need the correct position to be able to
+    // compute intersections).
+    m_shader.setModelMatrix(DirectX::XMMatrixIdentity());
+    m_shader.setNormalRotationMatrix(DirectX::XMMatrixIdentity());
+    m_shader.setModelColor({1.0f, 1.0f, 1.0f, 1.0f});
+    m_shader.updatePerModelConstantBuffer();
     m_model_bounding_box_mesh.render();
   }
 
@@ -88,6 +95,10 @@ void SceneNode::updateTransformation() {
     // relative to the origin point.
     m_world_transform = m_local_transform;
     m_world_rotation_matrix = DirectX::XMMatrixRotationQuaternion(m_rotation);
+  }
+
+  if (m_model) {
+    m_model_bounding_box_mesh.updateVerticesFromBoundingBox(getTransformedBoundingBox());
   }
 
   for (SceneNode *child : m_children) {
@@ -161,4 +172,8 @@ void SceneNode::setGrabbable(bool grabbable) {
 
 std::unordered_set<SceneNode*> SceneNode::getGrabbableInstances() {
   return s_grabbable_instances;
+}
+
+bool SceneNode::intersects(DirectX::BoundingOrientedBox other) {
+  return getTransformedBoundingBox().Intersects(other);
 }

--- a/src/scene_node.cpp
+++ b/src/scene_node.cpp
@@ -9,7 +9,6 @@ SceneNode::SceneNode(Model* model) {
   m_model = model;
   buildBoundingBox();
   m_parent = NULL;
-  m_shader = Shader::loadOrCreate(SHADERS_FOLDER "/ambient.hlsl");
 }
 
 void SceneNode::buildBoundingBox() {
@@ -52,23 +51,24 @@ void SceneNode::render() {
   }
 
   if (m_model) {
-    m_shader.activate();
+    m_model->m_shader.activate();
 
     // Update the shader with the transform
-    m_shader.setModelMatrix(m_world_transform);
-    m_shader.setNormalRotationMatrix(m_world_rotation_matrix);
+    m_model->m_shader.setModelMatrix(m_world_transform);
+    m_model->m_shader.setNormalRotationMatrix(m_world_rotation_matrix);
     if (m_intersected_in_current_frame) {
-      m_shader.setModelColor({1.0f, 0.0f, 0.0f, 1.0f});
+      m_model->m_shader.setModelColor({1.0f, 0.0f, 0.0f, 1.0f});
     }
     else {
-      m_shader.setModelColor(m_model->getColor());
+      m_model->m_shader.setModelColor(m_model->getColor());
     }
-    m_shader.updatePerModelConstantBuffer();
+    m_model->m_shader.updatePerModelConstantBuffer();
     m_model->render();
 
     // Set shader variables to identities, as the bounding box is already updated
     // with the correct position (as we need the correct position to be able to
     // compute intersections).
+    // TODO: the bounding box mesh should also have its own shader!
     m_shader.setModelMatrix(DirectX::XMMatrixIdentity());
     m_shader.setNormalRotationMatrix(DirectX::XMMatrixIdentity());
     m_shader.setModelColor({1.0f, 1.0f, 1.0f, 1.0f});

--- a/src/scene_node.cpp
+++ b/src/scene_node.cpp
@@ -1,0 +1,73 @@
+#include <xre/scene_node.h>
+
+SceneNode::SceneNode() {
+  m_parent = NULL;
+  m_model = NULL;
+  m_shader = Shader::loadOrCreate(SHADERS_FOLDER "/ambient.hlsl");
+}
+
+SceneNode::SceneNode(Model* model) {
+  m_model = model;
+  m_parent = NULL;
+  m_shader = Shader::loadOrCreate(SHADERS_FOLDER "/ambient.hlsl");
+}
+
+SceneNode::~SceneNode() {
+ m_children.clear();
+}
+
+void SceneNode::addChildNode(SceneNode &child) {
+  m_children.push_back(&child);
+  child.m_parent = this;
+}
+
+void SceneNode::render() {
+  m_shader.activate();
+  // TODO: remove `m_shader` param when models have a default shader
+  if (m_model) {
+    // Update the shader with the transform
+    m_shader.setModelMatrix(m_world_transform);
+    m_shader.setNormalRotationMatrix(m_world_rotation_matrix);
+    // m_shader.setModelColor(m_model->getColor());
+    m_shader.updatePerModelConstantBuffer();
+    m_model->render(m_shader);
+  }
+
+  for (SceneNode *child : m_children) {
+    child->render();
+  }
+}
+
+void SceneNode::updateTransformation() {
+  // Update the local transform
+  m_local_transform = DirectX::XMMatrixTranspose(
+    DirectX::XMMatrixAffineTransformation(
+      m_scaling,
+      DirectX::g_XMZero,
+      m_rotation,
+      m_translation
+    )
+  );
+
+  if (m_parent) {
+    m_world_transform = DirectX::XMMatrixMultiply(
+      m_parent->m_world_transform,
+      m_local_transform
+    );
+
+    m_world_rotation_matrix = DirectX::XMMatrixRotationQuaternion(
+      DirectX::XMQuaternionMultiply(m_parent->m_rotation, m_rotation)
+    );
+  }
+  else {
+    // No parent, is the root node, which means its local transform
+    // is also its world transform, since the local transform is applied
+    // relative to the origin point.
+    m_world_transform = m_local_transform;
+    m_world_rotation_matrix = DirectX::XMMatrixRotationQuaternion(m_rotation);
+  }
+
+  for (SceneNode *child : m_children) {
+    child->updateTransformation();
+  }
+}

--- a/src/scene_node.cpp
+++ b/src/scene_node.cpp
@@ -41,6 +41,11 @@ void SceneNode::addChildNode(SceneNode &child) {
   child.m_parent = this;
 }
 
+void SceneNode::addChildNode(SceneNode *child) {
+  m_children.push_back(child);
+  child->m_parent = this;
+}
+
 void SceneNode::render() {
   if (m_model) {
     m_shader.activate();

--- a/src/scene_node.cpp
+++ b/src/scene_node.cpp
@@ -3,13 +3,13 @@
 SceneNode::SceneNode() {
   m_parent = NULL;
   m_model = NULL;
-  m_shader = Shader::loadOrCreate(SHADERS_FOLDER "/ambient.hlsl");
+  m_shader = Shader::loadOrCreate(SHADERS_FOLDER "/color.hlsl");
 }
 
 SceneNode::SceneNode(Model* model) {
   m_model = model;
   m_parent = NULL;
-  m_shader = Shader::loadOrCreate(SHADERS_FOLDER "/ambient.hlsl");
+  m_shader = Shader::loadOrCreate(SHADERS_FOLDER "/color.hlsl");
 }
 
 SceneNode::~SceneNode() {

--- a/src/scene_node.cpp
+++ b/src/scene_node.cpp
@@ -14,6 +14,17 @@ SceneNode::SceneNode(Model* model) {
 SceneNode::SceneNode(Model* model, SceneNode &parent) {
   m_model = model;
   buildBoundingBox();
+  m_parent = &parent;
+  parent.addChildNode(this);
+}
+
+SceneNode::SceneNode(Renderable* renderable) {
+  m_renderable = renderable;
+}
+
+SceneNode::SceneNode(Renderable* renderable, SceneNode &parent) {
+  m_renderable = renderable;
+  m_parent = &parent;
   parent.addChildNode(this);
 }
 
@@ -75,6 +86,9 @@ void SceneNode::render() {
     // with the correct position (as we need the correct position to be able to
     // compute intersections).
     m_model_bounding_box_mesh.render();
+  }
+  else if (m_renderable) {
+    m_renderable->render();
   }
 
   for (SceneNode *child : m_children) {

--- a/src/scene_node.cpp
+++ b/src/scene_node.cpp
@@ -68,11 +68,6 @@ void SceneNode::render() {
     // Set shader variables to identities, as the bounding box is already updated
     // with the correct position (as we need the correct position to be able to
     // compute intersections).
-    // TODO: the bounding box mesh should also have its own shader!
-    m_shader.setModelMatrix(DirectX::XMMatrixIdentity());
-    m_shader.setNormalRotationMatrix(DirectX::XMMatrixIdentity());
-    m_shader.setModelColor({1.0f, 1.0f, 1.0f, 1.0f});
-    m_shader.updatePerModelConstantBuffer();
     m_model_bounding_box_mesh.render();
   }
 

--- a/src/shader.cpp
+++ b/src/shader.cpp
@@ -13,8 +13,11 @@ Shader::Shader(const char *shader_path) {
   std::wstring w_obj_location = Utils::stringToWString(obj_location);
 
   // Load and compile the pixel and vertex shaders
-  ID3D10Blob *vertex_shader_blob, *pixel_shader_blob, *errors_blob;
+  ID3DBlob *vertex_shader_blob = nullptr;
+  ID3DBlob *pixel_shader_blob = nullptr;
+  ID3DBlob *errors_blob = nullptr;
   D3DCompileFromFile(w_obj_location.c_str(), 0, D3D_COMPILE_STANDARD_FILE_INCLUDE, "VShader", "vs_4_0", D3DCOMPILE_OPTIMIZATION_LEVEL3, 0, &vertex_shader_blob, &errors_blob);
+
   if (errors_blob) {
     std::cout << reinterpret_cast<const char *>(errors_blob->GetBufferPointer()) << std::endl;
     Utils::exitWithMessage("The vertex shader failed to compile.");

--- a/src/text.cpp
+++ b/src/text.cpp
@@ -25,9 +25,6 @@ Text::Text(const char* sentence) {
 void Text::buildMeshesFromSentence(const char* sentence) {
   int lenght = strlen(sentence);
 
-  float x_position = 0.0;
-  float y_position = 0.0;
-
   float x_offset = -0.95f;
   float char_height = 0.1;
   float char_width = 0.05f;
@@ -77,9 +74,21 @@ void Text::buildMeshesFromSentence(const char* sentence) {
     }
   }
 
-  m_bitmap = Bitmap(vertices, indices, DATA_FOLDER "/fonts/DejaVuSansMono128NoAA.png");
+  // Call general initialize method
+  initialize(vertices, indices);
+
+  // Load the texture
+  std::wstring filepath = Utils::stringToWString(DATA_FOLDER "/fonts/DejaVuSansMono128NoAA.png");
+  ID3D11Resource *texture; // Throwaway variable
+  HRESULT result = DirectX::CreateWICTextureFromFile(s_device, s_device_context, filepath.c_str(), &texture, &m_texture_view);
+  Utils::checkHresult(result, "Failed to load the texture");
+
+  m_shader = Shader::loadOrCreate(SHADERS_FOLDER "/bitmap.hlsl");
 }
 
 void Text::render() {
-  m_bitmap.render();
+  m_shader.activate();
+  m_shader.updatePerModelConstantBuffer();
+
+  Renderable::render();
 }


### PR DESCRIPTION
This PR implements simple scene graphs, which allows for easier rendering of complex scenes, as only the root node of the scene must be rendered.
In addition, transforming a parent node will also update child nodes, as transforms are now always relative to the parent node.